### PR TITLE
Fix Python package installation environment error

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,52 @@ This release focused on **usability, automation, and polish** with 14 new featur
 
 ### Installation
 
+#### Option 1: Install from PyPI (Recommended)
+
+```bash
+# Using pipx (recommended - manages virtual environment automatically)
+pipx install argus-overview
+
+# Run
+argus-overview
+```
+
+If you don't have pipx installed:
+```bash
+# Ubuntu/Debian
+sudo apt install pipx
+pipx ensurepath
+
+# Fedora
+sudo dnf install pipx
+pipx ensurepath
+
+# Arch
+sudo pacman -S python-pipx
+pipx ensurepath
+```
+
+<details>
+<summary>Alternative: Install in a virtual environment</summary>
+
+```bash
+# Create and activate virtual environment
+python3 -m venv ~/.venv/argus
+source ~/.venv/argus/bin/activate
+
+# Install
+pip install argus-overview
+
+# Run (with venv activated)
+argus-overview
+```
+
+**Note:** Modern Linux distributions (Debian 12+, Ubuntu 23.04+, Fedora 38+) use PEP 668 to protect the system Python. Running `pip install argus-overview` directly will show an "externally-managed-environment" error. Use `pipx` or a virtual environment instead.
+
+</details>
+
+#### Option 2: Install from Source
+
 ```bash
 # One-liner install
 curl -sSL https://raw.githubusercontent.com/AreteDriver/Argus_Overview/main/install.sh | bash


### PR DESCRIPTION
Modern Linux distributions (Debian 12+, Ubuntu 23.04+, Fedora 38+) use PEP 668 to protect the system Python, causing "externally-managed-environment" errors when running pip install directly.

- Add pipx as the recommended installation method
- Include pipx installation commands for major distros
- Add virtual environment alternative in collapsible section
- Explain PEP 668 and the error users may encounter
- Reorganize installation options (PyPI first, source second)

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring

## Testing

How did you test this?

- [ ] Tested on Linux (specify distro):
- [ ] Tested with EVE Online running
- [ ] Tested with multiple EVE windows

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
