### PR TITLE
fix: correct Windows download links pointing to non-existent repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ General settings with auto-save and notifications.
 | Platform | Status | Download |
 |----------|--------|----------|
 | **Linux** | Full-featured native application | [Portable Tarball / AppImage](https://github.com/AreteDriver/Argus_Overview/releases) |
-| **Windows** | Standalone .exe available | [Download Windows .exe](https://github.com/AreteDriver/Argus_Overview_Windows/releases/latest) |
+| **Windows** | Standalone .exe available | [Download Windows .exe](https://github.com/AreteDriver/Argus_Overview/releases) |
 
 - **Linux**: This repository - X11/XWayland support with native tools. **Portable tarball** runs directly after unpacking.
-- **Windows**: [Argus_Overview_Windows](https://github.com/AreteDriver/Argus_Overview_Windows) - Native Win32 API implementation
+- **Windows**: See [windows/README_WINDOWS.md](windows/README_WINDOWS.md) for Windows-specific instructions. Uses native Win32 API implementation.
 
 ## ☕ Support Development
 

--- a/windows/README_WINDOWS.md
+++ b/windows/README_WINDOWS.md
@@ -26,7 +26,7 @@ Professional multi-boxing tool for EVE Online on Windows.
 
 ### Option 1: Download Release
 
-1. Download `Argus-Overview-v2.4-Windows.zip` from [Releases](https://github.com/AreteDriver/Argus_Overview/releases)
+1. Download `Argus-Overview-Windows.zip` from [Releases](https://github.com/AreteDriver/Argus_Overview/releases)
 2. Extract and run the executable
 3. That's it! No installation needed.
 


### PR DESCRIPTION
The Windows .exe links were pointing to a separate Argus_Overview_Windows
repo that doesn't exist (404 errors). Windows code is actually in the
windows/ subdirectory of this repo, so updated links to point to correct
locations.

https://claude.ai/code/session_01X81AbANXbBW4DFEjZDMd7u