### PR TITLE
fix: harden exception handling, thread safety, resource cleanup, and type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ argus-overview = "main:main"
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 exclude = ["windows/", "build/", "dist/", ".venv/"]
 
 [tool.ruff.lint]

--- a/src/argus_overview/core/character_manager.py
+++ b/src/argus_overview/core/character_manager.py
@@ -9,7 +9,6 @@ import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
 
 
 def sanitize_character_name(name: str) -> str:
@@ -40,15 +39,15 @@ class Character:
     role: str = "DPS"  # Miner, Scout, DPS, Logi, Hauler, etc.
     notes: str = ""
     is_main: bool = False
-    window_id: Optional[str] = None  # Assigned when logged in
-    last_seen: Optional[str] = None
+    window_id: str | None = None  # Assigned when logged in
+    last_seen: str | None = None
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Convert to dictionary"""
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: Dict) -> "Character":
+    def from_dict(cls, data: dict) -> "Character":
         """Create from dictionary"""
         return cls(**data)
 
@@ -59,17 +58,17 @@ class Team:
 
     name: str
     description: str = ""
-    characters: List[str] = field(default_factory=list)  # Character names
+    characters: list[str] = field(default_factory=list)  # Character names
     layout_name: str = "Default"  # Associated layout preset
     color: str = "#4287f5"  # Team color for UI
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Convert to dictionary"""
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: Dict) -> "Team":
+    def from_dict(cls, data: dict) -> "Team":
         """Create from dictionary"""
         return cls(**data)
 
@@ -77,7 +76,7 @@ class Team:
 class CharacterManager:
     """Manages character database and teams"""
 
-    def __init__(self, config_dir: Optional[Path] = None):
+    def __init__(self, config_dir: Path | None = None):
         self.logger = logging.getLogger(__name__)
 
         if config_dir is None:
@@ -89,8 +88,8 @@ class CharacterManager:
         self.characters_file = self.config_dir / "characters.json"
         self.teams_file = self.config_dir / "teams.json"
 
-        self.characters: Dict[str, Character] = {}
-        self.teams: Dict[str, Team] = {}
+        self.characters: dict[str, Character] = {}
+        self.teams: dict[str, Team] = {}
 
         self._load_data()
 
@@ -242,19 +241,19 @@ class CharacterManager:
         self.save_data()
         return True
 
-    def get_character(self, char_name: str) -> Optional[Character]:
+    def get_character(self, char_name: str) -> Character | None:
         """Get character by name"""
         return self.characters.get(char_name)
 
-    def get_all_characters(self) -> List[Character]:
+    def get_all_characters(self) -> list[Character]:
         """Get all characters"""
         return list(self.characters.values())
 
-    def get_characters_by_account(self, account: str) -> List[Character]:
+    def get_characters_by_account(self, account: str) -> list[Character]:
         """Get all characters in an account"""
         return [char for char in self.characters.values() if char.account == account]
 
-    def get_accounts(self) -> List[str]:
+    def get_accounts(self) -> list[str]:
         """Get all account names"""
         accounts = set()
         for char in self.characters.values():
@@ -321,15 +320,15 @@ class CharacterManager:
             return True
         return False
 
-    def get_team(self, team_name: str) -> Optional[Team]:
+    def get_team(self, team_name: str) -> Team | None:
         """Get team by name"""
         return self.teams.get(team_name)
 
-    def get_all_teams(self) -> List[Team]:
+    def get_all_teams(self) -> list[Team]:
         """Get all teams"""
         return list(self.teams.values())
 
-    def get_teams_for_character(self, char_name: str) -> List[Team]:
+    def get_teams_for_character(self, char_name: str) -> list[Team]:
         """Get all teams containing a character"""
         return [team for team in self.teams.values() if char_name in team.characters]
 
@@ -353,19 +352,19 @@ class CharacterManager:
         self.save_data()
         return True
 
-    def get_character_by_window(self, window_id: str) -> Optional[Character]:
+    def get_character_by_window(self, window_id: str) -> Character | None:
         """Find character by window ID"""
         for char in self.characters.values():
             if char.window_id == window_id:
                 return char
         return None
 
-    def get_active_characters(self) -> List[Character]:
+    def get_active_characters(self) -> list[Character]:
         """Get characters currently logged in (with window IDs)"""
         return [char for char in self.characters.values() if char.window_id]
 
     # Import from EVE files
-    def import_from_eve_sync(self, eve_characters: List) -> int:
+    def import_from_eve_sync(self, eve_characters: list) -> int:
         """Import characters discovered from EVE installation files
 
         Args:
@@ -439,7 +438,7 @@ class CharacterManager:
         return imported
 
     # Auto-detection
-    def auto_assign_windows(self, windows: List[tuple]) -> Dict[str, str]:
+    def auto_assign_windows(self, windows: list[tuple]) -> dict[str, str]:
         """Auto-assign windows to characters based on window titles
 
         Args:

--- a/src/argus_overview/core/config_watcher.py
+++ b/src/argus_overview/core/config_watcher.py
@@ -4,8 +4,9 @@ v2.2 Feature: Automatically detect and apply config changes without restart
 """
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any
 
 from PySide6.QtCore import QObject, QTimer, Signal
 
@@ -57,13 +58,13 @@ class ConfigWatcher(QObject):
         self._debounce_timer.timeout.connect(self._emit_change)
 
         # Watchdog observer (Any type to handle conditional import)
-        self._observer: Optional[Any] = None
+        self._observer: Any | None = None
         self._running = False
 
         # Fallback polling timer
         self._poll_timer = QTimer(self)
         self._poll_timer.timeout.connect(self._check_file)
-        self._last_mtime: Optional[float] = None
+        self._last_mtime: float | None = None
 
     def start(self):
         """Start watching for config changes"""
@@ -101,6 +102,7 @@ class ConfigWatcher(QObject):
         try:
             handler = ConfigFileHandler(self._on_file_changed)
             self._observer = Observer()
+            self._observer.daemon = True
             self._observer.schedule(handler, str(self.config_path.parent), recursive=False)
             self._observer.start()
             self.logger.info("Using watchdog for config monitoring")
@@ -130,8 +132,8 @@ class ConfigWatcher(QObject):
                 if self._last_mtime and current_mtime > self._last_mtime:
                     self._on_file_changed()
                 self._last_mtime = current_mtime
-        except Exception as e:
-            self.logger.debug(f"Error checking config file: {e}")
+        except OSError as e:
+            self.logger.debug("Error checking config file: %s", e)
 
     def _on_file_changed(self):
         """Handle file change - debounced"""

--- a/src/argus_overview/core/discovery.py
+++ b/src/argus_overview/core/discovery.py
@@ -6,9 +6,9 @@ v3.0: Cross-platform support via platform abstraction layer
 
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from PySide6.QtCore import QObject, QTimer, Signal
 
@@ -75,11 +75,11 @@ class AutoDiscovery(QObject):
         self.enabled = True
 
         # State
-        self.known_characters: Dict[str, DiscoveredCharacter] = {}
-        self.active_window_ids: Set[str] = set()
+        self.known_characters: dict[str, DiscoveredCharacter] = {}
+        self.active_window_ids: set[str] = set()
 
         # Callbacks
-        self._on_new_callback: Optional[Callable] = None
+        self._on_new_callback: Callable | None = None
 
         # Timer for background scanning
         self.scan_timer = QTimer(self)
@@ -196,7 +196,7 @@ class AutoDiscovery(QObject):
         except Exception as e:
             self.logger.error(f"Scan cycle error: {e}")
 
-    def _get_eve_windows(self) -> List[Tuple[str, str]]:
+    def _get_eve_windows(self) -> list[tuple[str, str]]:
         """
         Get all EVE Online windows using platform abstraction.
 
@@ -226,7 +226,7 @@ class AutoDiscovery(QObject):
 
         return False
 
-    def _extract_character_name(self, title: str) -> Optional[str]:
+    def _extract_character_name(self, title: str) -> str | None:
         """
         Extract character name from window title
 
@@ -243,7 +243,7 @@ class AutoDiscovery(QObject):
 
         return None
 
-    def get_known_characters(self) -> List[DiscoveredCharacter]:
+    def get_known_characters(self) -> list[DiscoveredCharacter]:
         """
         Get list of all known characters
 
@@ -252,7 +252,7 @@ class AutoDiscovery(QObject):
         """
         return list(self.known_characters.values())
 
-    def get_active_characters(self) -> List[DiscoveredCharacter]:
+    def get_active_characters(self) -> list[DiscoveredCharacter]:
         """
         Get list of currently active characters
 
@@ -279,7 +279,7 @@ class AutoDiscovery(QObject):
         self.active_window_ids.clear()
         self.logger.info("Character history cleared")
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """
         Serialize known characters to dict for config storage
 
@@ -298,7 +298,7 @@ class AutoDiscovery(QObject):
             ]
         }
 
-    def from_dict(self, data: Dict):
+    def from_dict(self, data: dict):
         """
         Load known characters from dict
 
@@ -324,7 +324,7 @@ class AutoDiscovery(QObject):
                     self.logger.error(f"Failed to load character: {e}")
 
 
-def scan_eve_windows() -> List[Tuple[str, str, str]]:
+def scan_eve_windows() -> list[tuple[str, str, str]]:
     """
     One-shot scan for all EVE windows.
     Convenience function for one-click import.

--- a/src/argus_overview/core/eve_settings_sync.py
+++ b/src/argus_overview/core/eve_settings_sync.py
@@ -12,7 +12,6 @@ import shutil
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
 
 from argus_overview.platform import get_eve_path_resolver
 
@@ -25,10 +24,10 @@ class EVECharacterSettings:
     character_id: str
     settings_dir: Path
     core_char_file: Path
-    core_user_file: Optional[Path] = None
-    user_id: Optional[str] = None
+    core_user_file: Path | None = None
+    user_id: str | None = None
     has_settings: bool = False
-    last_login: Optional[datetime] = None
+    last_login: datetime | None = None
 
 
 @dataclass
@@ -37,9 +36,9 @@ class EVECharacterInfo:
 
     character_id: str
     character_name: str
-    user_id: Optional[str] = None
-    settings_path: Optional[Path] = None
-    last_seen: Optional[datetime] = None
+    user_id: str | None = None
+    settings_path: Path | None = None
+    last_seen: datetime | None = None
     has_settings: bool = False
 
 
@@ -56,9 +55,9 @@ class EVESettingsSync:
         self.eve_paths = path_resolver.get_eve_settings_paths()
         self.eve_logs_paths = path_resolver.get_eve_logs_paths()
 
-        self.custom_paths: List[Path] = []
-        self.character_settings: Dict[str, EVECharacterSettings] = {}
-        self.character_id_to_name: Dict[str, str] = {}  # Cache of ID -> name mappings
+        self.custom_paths: list[Path] = []
+        self.character_settings: dict[str, EVECharacterSettings] = {}
+        self.character_id_to_name: dict[str, str] = {}  # Cache of ID -> name mappings
         self._load_character_names_from_logs()
 
     def add_custom_path(self, path: Path):
@@ -132,7 +131,7 @@ class EVESettingsSync:
             except OSError as e:
                 self.logger.debug(f"Error iterating {base_path}: {e}")
 
-    def _parse_log_for_char_name(self, log_file: Path) -> Optional[str]:
+    def _parse_log_for_char_name(self, log_file: Path) -> str | None:
         """Parse a log file to extract the character name from Listener line."""
         try:
             with open(log_file, encoding="utf-8", errors="replace") as f:
@@ -146,7 +145,7 @@ class EVESettingsSync:
             self.logger.debug(f"Error reading log {log_file}: {e}")
         return None
 
-    def _create_char_info(self, char_file: Path, settings_dir: Path) -> Optional[EVECharacterInfo]:
+    def _create_char_info(self, char_file: Path, settings_dir: Path) -> EVECharacterInfo | None:
         """Create EVECharacterInfo from a core_char_*.dat file."""
         match = re.search(r"core_char_(\d+)\.dat$", char_file.name)
         if not match:
@@ -169,7 +168,7 @@ class EVESettingsSync:
             has_settings=True,
         )
 
-    def get_all_known_characters(self) -> List[EVECharacterInfo]:
+    def get_all_known_characters(self) -> list[EVECharacterInfo]:
         """Get all known characters from EVE installation (even logged off ones)
 
         This scans the EVE settings directory for core_char_*.dat files
@@ -197,7 +196,7 @@ class EVESettingsSync:
         self.logger.info(f"Found {len(characters)} characters in EVE settings")
         return characters
 
-    def scan_for_characters(self) -> List[EVECharacterSettings]:
+    def scan_for_characters(self) -> list[EVECharacterSettings]:
         """Scan for EVE character settings
 
         Scans settings directories for core_char_*.dat files and returns
@@ -225,7 +224,7 @@ class EVESettingsSync:
 
     def _parse_char_file(
         self, char_file: Path, settings_dir: Path
-    ) -> Optional[EVECharacterSettings]:
+    ) -> EVECharacterSettings | None:
         """Parse a core_char_*.dat file to extract character settings
 
         Args:
@@ -264,8 +263,8 @@ class EVESettingsSync:
             return None
 
     def sync_settings(
-        self, source_char: str, target_chars: List[str], backup: bool = True
-    ) -> Dict[str, bool]:
+        self, source_char: str, target_chars: list[str], backup: bool = True
+    ) -> dict[str, bool]:
         """Synchronize settings from source to target characters
 
         Args:
@@ -276,7 +275,7 @@ class EVESettingsSync:
         Returns:
             Dict mapping target character names to success status
         """
-        results: Dict[str, bool] = {}
+        results: dict[str, bool] = {}
 
         if source_char not in self.character_settings:
             self.logger.error(f"Source character '{source_char}' not found")
@@ -369,7 +368,7 @@ class EVESettingsSync:
             self.logger.error(f"Settings copy error: {e}")
             return False
 
-    def get_settings_summary(self, char_name: str) -> Optional[Dict]:
+    def get_settings_summary(self, char_name: str) -> dict | None:
         """Get summary of character's settings
 
         Args:
@@ -398,7 +397,7 @@ class EVESettingsSync:
             else 0,
         }
 
-    def list_available_characters(self) -> List[str]:
+    def list_available_characters(self) -> list[str]:
         """Get list of characters with available settings
 
         Returns:

--- a/src/argus_overview/core/hotkey_manager.py
+++ b/src/argus_overview/core/hotkey_manager.py
@@ -1,7 +1,7 @@
 """Global hotkey management - supports both modifier combos and single keys"""
 
 import logging
-from typing import Callable, Dict, Optional, Set
+from collections.abc import Callable
 
 from pynput import keyboard
 from PySide6.QtCore import QObject, Signal
@@ -14,17 +14,17 @@ class HotkeyManager(QObject):
 
     def __init__(self):
         super().__init__()
-        self.hotkeys: Dict[str, Dict] = {}
-        self.combo_listener: Optional[keyboard.GlobalHotKeys] = None
-        self.key_listener: Optional[keyboard.Listener] = None
+        self.hotkeys: dict[str, dict] = {}
+        self.combo_listener: keyboard.GlobalHotKeys | None = None
+        self.key_listener: keyboard.Listener | None = None
         self.logger = logging.getLogger(__name__)
 
         # Track single-key hotkeys separately
-        self.single_key_hotkeys: Dict[str, Dict] = {}  # key_char -> {name, callback}
-        self.combo_hotkeys: Dict[str, Dict] = {}  # combo_string -> {name, callback}
+        self.single_key_hotkeys: dict[str, dict] = {}  # key_char -> {name, callback}
+        self.combo_hotkeys: dict[str, dict] = {}  # combo_string -> {name, callback}
 
         # Track currently pressed modifiers
-        self.pressed_modifiers: Set[str] = set()
+        self.pressed_modifiers: set[str] = set()
 
     def _normalize_combo(self, key_combo: str) -> str:
         """Normalize hotkey combo for pynput compatibility.

--- a/src/argus_overview/core/layout_manager.py
+++ b/src/argus_overview/core/layout_manager.py
@@ -10,7 +10,6 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional
 
 
 def sanitize_filename(name: str) -> str:
@@ -66,20 +65,20 @@ class LayoutPreset:
 
     name: str
     description: str = ""
-    windows: List[WindowLayout] = field(default_factory=list)
+    windows: list[WindowLayout] = field(default_factory=list)
     refresh_rate: int = 30
     grid_pattern: str = "custom"
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
     modified_at: str = field(default_factory=lambda: datetime.now().isoformat())
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Convert to dictionary"""
         data = asdict(self)
         data["windows"] = [asdict(w) for w in self.windows]
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict) -> "LayoutPreset":
+    def from_dict(cls, data: dict) -> "LayoutPreset":
         """Create from dictionary"""
         windows_data = data.pop("windows", [])
         preset = cls(**data)
@@ -90,7 +89,7 @@ class LayoutPreset:
 class LayoutManager:
     """Manages layout presets and grid patterns"""
 
-    def __init__(self, config_dir: Optional[Path] = None):
+    def __init__(self, config_dir: Path | None = None):
         self.logger = logging.getLogger(__name__)
 
         if config_dir is None:
@@ -102,7 +101,7 @@ class LayoutManager:
         self.layouts_dir = self.config_dir / "layouts"
         self.layouts_dir.mkdir(exist_ok=True)
 
-        self.presets: Dict[str, LayoutPreset] = {}
+        self.presets: dict[str, LayoutPreset] = {}
         self._load_presets()
 
     @staticmethod
@@ -199,16 +198,16 @@ class LayoutManager:
             self.logger.error(f"Failed to delete preset '{preset_name}': {e}")
             return False
 
-    def get_preset(self, preset_name: str) -> Optional[LayoutPreset]:
+    def get_preset(self, preset_name: str) -> LayoutPreset | None:
         """Get a layout preset by name"""
         return self.presets.get(preset_name)
 
-    def get_all_presets(self) -> List[LayoutPreset]:
+    def get_all_presets(self) -> list[LayoutPreset]:
         """Get all layout presets"""
         return list(self.presets.values())
 
     def create_preset_from_current(
-        self, name: str, description: str, current_windows: Dict
+        self, name: str, description: str, current_windows: dict
     ) -> LayoutPreset:
         """Create a preset from current window positions
 
@@ -242,7 +241,7 @@ class LayoutManager:
     # Grid Pattern Calculations - Helper methods
     def _calc_uniform_grid(
         self,
-        windows: List[str],
+        windows: list[str],
         cols: int,
         rows: int,
         max_windows: int,
@@ -251,7 +250,7 @@ class LayoutManager:
         screen_width: int,
         screen_height: int,
         spacing: int,
-    ) -> Dict[str, Dict]:
+    ) -> dict[str, dict]:
         """Calculate uniform grid layout (2x2, etc.)"""
         win_width = (screen_width - spacing * (cols + 1)) // cols
         win_height = (screen_height - spacing * (rows + 1)) // rows
@@ -268,14 +267,14 @@ class LayoutManager:
 
     def _calc_horizontal_row(
         self,
-        windows: List[str],
+        windows: list[str],
         count: int,
         screen_x: int,
         screen_y: int,
         screen_width: int,
         screen_height: int,
         spacing: int,
-    ) -> Dict[str, Dict]:
+    ) -> dict[str, dict]:
         """Calculate horizontal row layout (3x1, 4x1)"""
         win_width = (screen_width - spacing * (count + 1)) // count
         win_height = screen_height - spacing * 2
@@ -291,14 +290,14 @@ class LayoutManager:
 
     def _calc_vertical_column(
         self,
-        windows: List[str],
+        windows: list[str],
         count: int,
         screen_x: int,
         screen_y: int,
         screen_width: int,
         screen_height: int,
         spacing: int,
-    ) -> Dict[str, Dict]:
+    ) -> dict[str, dict]:
         """Calculate vertical column layout (1x3)"""
         win_width = screen_width - spacing * 2
         win_height = (screen_height - spacing * (count + 1)) // count
@@ -313,8 +312,8 @@ class LayoutManager:
         }
 
     def calculate_grid_layout(
-        self, pattern: GridPattern, windows: List[str], screen_geometry: Dict, spacing: int = 10
-    ) -> Dict[str, Dict]:
+        self, pattern: GridPattern, windows: list[str], screen_geometry: dict, spacing: int = 10
+    ) -> dict[str, dict]:
         """Calculate grid layout positions
 
         Args:
@@ -350,13 +349,13 @@ class LayoutManager:
 
     def _calc_main_plus_sides(
         self,
-        windows: List[str],
+        windows: list[str],
         screen_x: int,
         screen_y: int,
         screen_width: int,
         screen_height: int,
         spacing: int,
-    ) -> Dict[str, Dict]:
+    ) -> dict[str, dict]:
         """Calculate main + sides layout"""
         layouts = {}
         num_windows = len(windows)
@@ -382,8 +381,8 @@ class LayoutManager:
         return layouts
 
     def _calc_cascade(
-        self, windows: List[str], screen_x: int, screen_y: int, spacing: int
-    ) -> Dict[str, Dict]:
+        self, windows: list[str], screen_x: int, screen_y: int, spacing: int
+    ) -> dict[str, dict]:
         """Calculate cascade layout"""
         return {
             window_id: {
@@ -396,8 +395,8 @@ class LayoutManager:
         }
 
     def auto_arrange(
-        self, windows: List[str], pattern: GridPattern, screen_geometry: Dict, spacing: int = 10
-    ) -> Dict[str, Dict]:
+        self, windows: list[str], pattern: GridPattern, screen_geometry: dict, spacing: int = 10
+    ) -> dict[str, dict]:
         """Auto-arrange windows in a grid pattern
 
         Args:

--- a/src/argus_overview/core/position.py
+++ b/src/argus_overview/core/position.py
@@ -5,7 +5,6 @@ v2.2 Feature: Automatically position new thumbnails relative to existing ones
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Optional
 
 from PySide6.QtCore import QRect
 from PySide6.QtWidgets import QApplication
@@ -52,7 +51,7 @@ class PositionManager:
         self.logger = logging.getLogger(__name__)
 
         # Current positions of thumbnails
-        self.positions: Dict[str, ThumbnailPosition] = {}
+        self.positions: dict[str, ThumbnailPosition] = {}
 
         # Grid snapping enabled
         self.snap_to_grid = True
@@ -61,7 +60,7 @@ class PositionManager:
         self.locked = False
 
     def get_next_position(
-        self, window_id: str, preset_positions: Optional[Dict[str, ThumbnailPosition]] = None
+        self, window_id: str, preset_positions: dict[str, ThumbnailPosition] | None = None
     ) -> ThumbnailPosition:
         """
         Calculate position for a new thumbnail.
@@ -220,14 +219,14 @@ class PositionManager:
             x=snapped_x, y=snapped_y, width=position.width, height=position.height
         )
 
-    def _get_rightmost(self) -> Optional[ThumbnailPosition]:
+    def _get_rightmost(self) -> ThumbnailPosition | None:
         """Get the rightmost thumbnail position"""
         if not self.positions:
             return None
 
         return max(self.positions.values(), key=lambda p: p.x + p.width)
 
-    def _get_bottommost(self) -> Optional[ThumbnailPosition]:
+    def _get_bottommost(self) -> ThumbnailPosition | None:
         """Get the bottommost thumbnail position"""
         if not self.positions:
             return None
@@ -245,11 +244,11 @@ class PositionManager:
         # Fallback
         return QRect(0, 0, 1920, 1080)
 
-    def get_all_positions(self) -> Dict[str, ThumbnailPosition]:
+    def get_all_positions(self) -> dict[str, ThumbnailPosition]:
         """Get all current positions"""
         return self.positions.copy()
 
-    def apply_layout_preset(self, positions: Dict[str, ThumbnailPosition]):
+    def apply_layout_preset(self, positions: dict[str, ThumbnailPosition]):
         """
         Apply a layout preset to current thumbnails.
 
@@ -264,11 +263,11 @@ class PositionManager:
 
     def calculate_grid_positions(
         self,
-        window_ids: List[str],
+        window_ids: list[str],
         columns: int = 3,
-        start_x: Optional[int] = None,
-        start_y: Optional[int] = None,
-    ) -> Dict[str, ThumbnailPosition]:
+        start_x: int | None = None,
+        start_y: int | None = None,
+    ) -> dict[str, ThumbnailPosition]:
         """
         Calculate grid positions for thumbnails.
 

--- a/src/argus_overview/core/window_capture_threaded.py
+++ b/src/argus_overview/core/window_capture_threaded.py
@@ -28,7 +28,6 @@ v3.0: Cross-platform support via platform abstraction layer.
 """
 
 import logging
-from typing import List, Optional, Tuple
 
 from PIL import Image
 
@@ -72,7 +71,7 @@ class WindowCaptureThreaded:
         """
         return self._capture.capture_window_async(window_id, scale)
 
-    def get_result(self, timeout: float = 0.1) -> Optional[Tuple[str, str, Image.Image]]:
+    def get_result(self, timeout: float = 0.1) -> tuple[str, str, Image.Image] | None:
         """Get capture result if available.
 
         Returns:
@@ -80,7 +79,7 @@ class WindowCaptureThreaded:
         """
         return self._capture.get_result(timeout)
 
-    def get_window_list(self) -> List[Tuple[str, str]]:
+    def get_window_list(self) -> list[tuple[str, str]]:
         """Get list of all windows."""
         return self._window_mgr.get_window_list()
 

--- a/src/argus_overview/intel/alerts.py
+++ b/src/argus_overview/intel/alerts.py
@@ -14,7 +14,6 @@ import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional
 
 from PySide6.QtCore import QObject, Signal
 
@@ -38,7 +37,7 @@ class AlertConfig:
     visual_border: bool = True
     visual_overlay: bool = True
     audio: bool = True
-    audio_file: Optional[Path] = None
+    audio_file: Path | None = None
     system_notification: bool = False
 
     # Thresholds
@@ -81,7 +80,7 @@ class AlertDispatcher(QObject):
     overlay_requested = Signal(object)  # IntelReport
     alert_triggered = Signal(object, object)  # IntelReport, AlertType
 
-    def __init__(self, config: Optional[AlertConfig] = None, parent: Optional[QObject] = None):
+    def __init__(self, config: AlertConfig | None = None, parent: QObject | None = None):
         """
         Initialize the alert dispatcher.
 
@@ -234,7 +233,7 @@ class AlertDispatcher(QObject):
         except Exception as e:
             self.logger.error(f"Error playing audio: {e}")
 
-    def _default_audio(self, threat_level: ThreatLevel) -> Optional[Path]:
+    def _default_audio(self, threat_level: ThreatLevel) -> Path | None:
         """
         Get default audio file for threat level.
 

--- a/src/argus_overview/intel/log_watcher.py
+++ b/src/argus_overview/intel/log_watcher.py
@@ -16,7 +16,6 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Set
 
 from PySide6.QtCore import QObject, QTimer, Signal
 
@@ -55,9 +54,9 @@ class ChatLogWatcher(QObject):
 
     def __init__(
         self,
-        log_paths: Optional[List[Path]] = None,
+        log_paths: list[Path] | None = None,
         poll_interval_ms: int = 1000,
-        parent: Optional[QObject] = None,
+        parent: QObject | None = None,
     ):
         """
         Initialize the chat log watcher.
@@ -73,19 +72,19 @@ class ChatLogWatcher(QObject):
         self.poll_interval_ms = poll_interval_ms
 
         # Track file positions for tailing
-        self.file_positions: Dict[Path, int] = {}
+        self.file_positions: dict[Path, int] = {}
 
         # Currently monitored channels (filenames without date suffix)
-        self.monitored_channels: Set[str] = set()
+        self.monitored_channels: set[str] = set()
 
         # Polling timer
         self.poll_timer = QTimer(self)
         self.poll_timer.timeout.connect(self._poll_files)
 
         self._running = False
-        self._log_directory: Optional[Path] = None
+        self._log_directory: Path | None = None
 
-    def find_log_directory(self) -> Optional[Path]:
+    def find_log_directory(self) -> Path | None:
         """
         Auto-detect EVE log directory.
 
@@ -139,7 +138,7 @@ class ChatLogWatcher(QObject):
         self.logger.warning("Could not find EVE chat log directory")
         return None
 
-    def get_active_channels(self) -> List[Path]:
+    def get_active_channels(self) -> list[Path]:
         """
         Get today's log files (channels currently open).
 
@@ -180,7 +179,7 @@ class ChatLogWatcher(QObject):
             return parts[0]
         return name
 
-    def parse_line(self, line: str, channel_name: str) -> Optional[ChatMessage]:
+    def parse_line(self, line: str, channel_name: str) -> ChatMessage | None:
         """
         Parse a single chat log line.
 
@@ -215,7 +214,7 @@ class ChatLogWatcher(QObject):
             raw_line=line,
         )
 
-    def tail_file(self, filepath: Path) -> List[ChatMessage]:
+    def tail_file(self, filepath: Path) -> list[ChatMessage]:
         """
         Read new lines from a log file.
 
@@ -268,7 +267,7 @@ class ChatLogWatcher(QObject):
 
         return messages
 
-    def set_monitored_channels(self, channels: List[str]):
+    def set_monitored_channels(self, channels: list[str]):
         """
         Set which channels to monitor.
 
@@ -319,7 +318,7 @@ class ChatLogWatcher(QObject):
         """Check if watcher is running."""
         return self._running
 
-    def get_log_directory(self) -> Optional[Path]:
+    def get_log_directory(self) -> Path | None:
         """Get the currently monitored log directory."""
         return self._log_directory
 

--- a/src/argus_overview/intel/parser.py
+++ b/src/argus_overview/intel/parser.py
@@ -14,7 +14,6 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional, Set
 
 
 class ThreatLevel(Enum):
@@ -31,16 +30,16 @@ class ThreatLevel(Enum):
 class IntelReport:
     """Represents parsed intel from a chat message."""
 
-    system: Optional[str]
+    system: str | None
     threat_level: ThreatLevel
-    hostile_count: Optional[int]
-    ship_types: List[str]
-    player_names: List[str]
+    hostile_count: int | None
+    ship_types: list[str]
+    player_names: list[str]
     raw_message: str
     timestamp: datetime = field(default_factory=datetime.now)
     channel: str = ""
     reporter: str = ""
-    jumps_from_current: Optional[int] = None
+    jumps_from_current: int | None = None
 
 
 class IntelParser:
@@ -55,7 +54,7 @@ class IntelParser:
     """
 
     # Common EVE ship types for detection (lowercase)
-    SHIP_TYPES: Set[str] = {
+    SHIP_TYPES: set[str] = {
         # Frigates
         "atron",
         "tristan",
@@ -218,7 +217,7 @@ class IntelParser:
     }
 
     # Capital ship types (subset for threat escalation)
-    CAPITAL_SHIPS: Set[str] = {
+    CAPITAL_SHIPS: set[str] = {
         "carrier",
         "dreadnought",
         "fax",
@@ -248,7 +247,7 @@ class IntelParser:
     }
 
     # Intel keywords
-    HOSTILE_KEYWORDS: Set[str] = {
+    HOSTILE_KEYWORDS: set[str] = {
         "hostile",
         "hostiles",
         "neut",
@@ -279,7 +278,7 @@ class IntelParser:
         "contacts",
     }
 
-    CLEAR_KEYWORDS: Set[str] = {
+    CLEAR_KEYWORDS: set[str] = {
         "clear",
         "clr",
         "empty",
@@ -291,7 +290,7 @@ class IntelParser:
         "all clear",
     }
 
-    MOVEMENT_KEYWORDS: Set[str] = {
+    MOVEMENT_KEYWORDS: set[str] = {
         "jumping",
         "jumped",
         "holding",
@@ -303,7 +302,7 @@ class IntelParser:
         "moving",
     }
 
-    def __init__(self, known_systems: Optional[Set[str]] = None):
+    def __init__(self, known_systems: set[str] | None = None):
         """
         Initialize the intel parser.
 
@@ -311,9 +310,9 @@ class IntelParser:
             known_systems: Optional set of known system names (lowercase)
         """
         self.logger = logging.getLogger(__name__)
-        self.known_systems: Set[str] = known_systems or self._load_default_systems()
+        self.known_systems: set[str] = known_systems or self._load_default_systems()
 
-    def _load_default_systems(self) -> Set[str]:
+    def _load_default_systems(self) -> set[str]:
         """
         Load a default set of known EVE system names.
 
@@ -356,10 +355,10 @@ class IntelParser:
     def parse(
         self,
         message: str,
-        timestamp: Optional[datetime] = None,
+        timestamp: datetime | None = None,
         channel: str = "",
         reporter: str = "",
-    ) -> Optional[IntelReport]:
+    ) -> IntelReport | None:
         """
         Parse a message for intel content.
 
@@ -438,7 +437,7 @@ class IntelParser:
 
         return None
 
-    def _extract_system(self, message: str) -> Optional[str]:
+    def _extract_system(self, message: str) -> str | None:
         """
         Extract system name from message.
 
@@ -469,7 +468,7 @@ class IntelParser:
 
         return None
 
-    def _extract_ships(self, message: str) -> List[str]:
+    def _extract_ships(self, message: str) -> list[str]:
         """
         Extract ship types from message.
 
@@ -489,7 +488,7 @@ class IntelParser:
 
         return found
 
-    def _extract_count(self, message: str) -> Optional[int]:
+    def _extract_count(self, message: str) -> int | None:
         """
         Extract hostile count from message.
 
@@ -525,7 +524,7 @@ class IntelParser:
 
         return None
 
-    def _extract_players(self, message: str) -> List[str]:
+    def _extract_players(self, message: str) -> list[str]:
         """
         Extract player names from message (basic heuristic).
 
@@ -556,7 +555,7 @@ class IntelParser:
 
         return players[:5]  # Limit to 5 names
 
-    def _assess_threat(self, count: Optional[int], ships: List[str]) -> ThreatLevel:
+    def _assess_threat(self, count: int | None, ships: list[str]) -> ThreatLevel:
         """
         Assess threat level based on intel.
 

--- a/src/argus_overview/platform/base.py
+++ b/src/argus_overview/platform/base.py
@@ -7,7 +7,6 @@ Each abstract class represents a category of platform-specific operations.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 from PIL import Image
 
@@ -40,7 +39,7 @@ class WindowManager(ABC):
     """
 
     @abstractmethod
-    def get_window_list(self) -> List[Tuple[str, str]]:
+    def get_window_list(self) -> list[tuple[str, str]]:
         """Get list of all visible windows.
 
         Returns:
@@ -48,7 +47,7 @@ class WindowManager(ABC):
         """
 
     @abstractmethod
-    def get_eve_windows(self) -> List[Tuple[str, str]]:
+    def get_eve_windows(self) -> list[tuple[str, str]]:
         """Get list of EVE Online windows.
 
         Returns:
@@ -108,7 +107,7 @@ class WindowManager(ABC):
         """
 
     @abstractmethod
-    def get_focused_window(self) -> Optional[str]:
+    def get_focused_window(self) -> str | None:
         """Get the currently focused window ID.
 
         Returns:
@@ -171,7 +170,7 @@ class WindowCapture(ABC):
         """
 
     @abstractmethod
-    def get_result(self, timeout: float = 0.1) -> Optional[Tuple[str, str, Image.Image]]:
+    def get_result(self, timeout: float = 0.1) -> tuple[str, str, Image.Image] | None:
         """Get capture result if available.
 
         Args:
@@ -182,7 +181,7 @@ class WindowCapture(ABC):
         """
 
     @abstractmethod
-    def capture_window_sync(self, window_id: str, scale: float = 1.0) -> Optional[Image.Image]:
+    def capture_window_sync(self, window_id: str, scale: float = 1.0) -> Image.Image | None:
         """Synchronous window capture.
 
         Args:
@@ -213,7 +212,7 @@ class ScreenManager(ABC):
         """
 
     @abstractmethod
-    def get_all_monitors(self) -> List[ScreenGeometry]:
+    def get_all_monitors(self) -> list[ScreenGeometry]:
         """Get geometry for all connected monitors.
 
         Returns:
@@ -229,7 +228,7 @@ class EVEPathResolver(ABC):
     """
 
     @abstractmethod
-    def get_eve_settings_paths(self) -> List[Path]:
+    def get_eve_settings_paths(self) -> list[Path]:
         """Get list of candidate EVE settings paths.
 
         Returns:
@@ -237,7 +236,7 @@ class EVEPathResolver(ABC):
         """
 
     @abstractmethod
-    def get_eve_logs_paths(self) -> List[Path]:
+    def get_eve_logs_paths(self) -> list[Path]:
         """Get list of candidate EVE game logs paths.
 
         Returns:

--- a/src/argus_overview/platform/linux.py
+++ b/src/argus_overview/platform/linux.py
@@ -13,9 +13,15 @@ import time
 import uuid
 from pathlib import Path
 from queue import Empty, Queue
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 from PIL import Image
+
+from argus_overview.utils.constants import (
+    X11_BACKOFF_SECONDS,
+    X11_DEFAULT_TIMEOUT,
+    X11_MAX_ATTEMPTS,
+)
 
 from .base import (
     EVEPathResolver,
@@ -37,42 +43,50 @@ EVE_TITLE_PATTERNS = [
     re.compile(r"^EVE Online - (.+)$"),
 ]
 
-# Retry defaults for X11 subprocess operations
-_DEFAULT_MAX_ATTEMPTS = 3
-_DEFAULT_BACKOFF_SECONDS = 0.15
-_DEFAULT_TIMEOUT = 2.0
+# Retry defaults — re-exported from constants for local use
+_DEFAULT_MAX_ATTEMPTS = X11_MAX_ATTEMPTS
+_DEFAULT_BACKOFF_SECONDS = X11_BACKOFF_SECONDS
+_DEFAULT_TIMEOUT = X11_DEFAULT_TIMEOUT
 
 # Module-level cache for wmctrl results
 _wmctrl_cache: dict = {"result": None, "timestamp": 0.0}
+_wmctrl_cache_lock = threading.Lock()
 _WMCTRL_CACHE_TTL = 1.0
 
 
 def _clear_wmctrl_cache() -> None:
     """Clear wmctrl cache (for testing)."""
-    _wmctrl_cache["result"] = None
-    _wmctrl_cache["timestamp"] = 0.0
+    with _wmctrl_cache_lock:
+        _wmctrl_cache["result"] = None
+        _wmctrl_cache["timestamp"] = 0.0
 
 
 def _get_wmctrl_window_list() -> str:
     """Get wmctrl -l output with caching (1 second TTL)."""
     now = time.monotonic()
-    if _wmctrl_cache["result"] is not None and now - _wmctrl_cache["timestamp"] < _WMCTRL_CACHE_TTL:
-        return _wmctrl_cache["result"]
+    with _wmctrl_cache_lock:
+        if (
+            _wmctrl_cache["result"] is not None
+            and now - _wmctrl_cache["timestamp"] < _WMCTRL_CACHE_TTL
+        ):
+            return _wmctrl_cache["result"]
 
     try:
         result = subprocess.run(["wmctrl", "-l"], capture_output=True, text=True, timeout=2)
         if result.returncode == 0:
-            _wmctrl_cache["result"] = result.stdout
-            _wmctrl_cache["timestamp"] = now
+            with _wmctrl_cache_lock:
+                _wmctrl_cache["result"] = result.stdout
+                _wmctrl_cache["timestamp"] = now
             return result.stdout
     except (subprocess.TimeoutExpired, OSError):
         pass
 
-    return _wmctrl_cache["result"] or ""
+    with _wmctrl_cache_lock:
+        return _wmctrl_cache["result"] or ""
 
 
 def run_x11_subprocess(
-    cmd: List[str],
+    cmd: list[str],
     timeout: float = _DEFAULT_TIMEOUT,
     max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
     backoff: float = _DEFAULT_BACKOFF_SECONDS,
@@ -97,7 +111,7 @@ def run_x11_subprocess(
         subprocess.SubprocessError: If all attempts fail
     """
     max_attempts = max(1, min(5, max_attempts))
-    last_error: Optional[Exception] = None
+    last_error: Exception | None = None
     cmd_str = " ".join(cmd)
 
     for attempt in range(1, max_attempts + 1):
@@ -134,7 +148,7 @@ def run_x11_subprocess(
 class WindowManagerLinux(WindowManager):
     """Linux window management using wmctrl and xdotool."""
 
-    def get_window_list(self) -> List[Tuple[str, str]]:
+    def get_window_list(self) -> list[tuple[str, str]]:
         """Get list of all windows using wmctrl."""
         try:
             result = run_x11_subprocess(["wmctrl", "-l"], timeout=2)
@@ -150,11 +164,11 @@ class WindowManagerLinux(WindowManager):
                         windows.append((window_id, window_title))
 
             return windows
-        except Exception as e:
-            logger.warning(f"Failed to get window list: {e}")
+        except subprocess.SubprocessError as e:
+            logger.warning("Failed to get window list: %s", e)
             return []
 
-    def get_eve_windows(self) -> List[Tuple[str, str]]:
+    def get_eve_windows(self) -> list[tuple[str, str]]:
         """Get list of EVE Online windows."""
         eve_windows = []
         output = _get_wmctrl_window_list()
@@ -253,7 +267,7 @@ class WindowManagerLinux(WindowManager):
             logger.warning("Failed to restore window %s: %s", window_id, e)
             return False
 
-    def get_focused_window(self) -> Optional[str]:
+    def get_focused_window(self) -> str | None:
         """Get the currently focused window ID."""
         try:
             result = run_x11_subprocess(
@@ -284,7 +298,8 @@ class WindowManagerLinux(WindowManager):
                 ["xdotool", "getwindowname", window_id], timeout=2, max_attempts=2
             )
             return result.stdout.decode("utf-8", errors="replace").strip()
-        except Exception:
+        except subprocess.SubprocessError as e:
+            logger.debug("Failed to get window title for %s: %s", window_id, e)
             return "Unknown"
 
 
@@ -295,7 +310,7 @@ class WindowCaptureLinux(WindowCapture):
         self.max_workers = max_workers
         self.capture_queue: Queue[Any] = Queue()
         self.result_queue: Queue[Any] = Queue()
-        self.workers: List[threading.Thread] = []
+        self.workers: list[threading.Thread] = []
         self._stop_event = threading.Event()
         self._stop_event.set()  # Start in stopped state
         self._window_mgr = WindowManagerLinux()
@@ -349,14 +364,14 @@ class WindowCaptureLinux(WindowCapture):
         self.capture_queue.put((window_id, scale, request_id))
         return request_id
 
-    def get_result(self, timeout: float = 0.1) -> Optional[Tuple[str, str, Image.Image]]:
+    def get_result(self, timeout: float = 0.1) -> tuple[str, str, Image.Image] | None:
         """Get capture result if available."""
         try:
             return self.result_queue.get(timeout=timeout)
         except Empty:
             return None
 
-    def capture_window_sync(self, window_id: str, scale: float = 1.0) -> Optional[Image.Image]:
+    def capture_window_sync(self, window_id: str, scale: float = 1.0) -> Image.Image | None:
         """Synchronous window capture using ImageMagick."""
         try:
             result = subprocess.run(
@@ -407,7 +422,7 @@ class ScreenManagerLinux(ScreenManager):
             logger.error(f"Failed to get screen geometry: {e}")
             return ScreenGeometry(0, 0, 1920, 1080, True)
 
-    def get_all_monitors(self) -> List[ScreenGeometry]:
+    def get_all_monitors(self) -> list[ScreenGeometry]:
         """Get geometry for all connected monitors."""
         try:
             result = subprocess.run(
@@ -424,9 +439,9 @@ class ScreenManagerLinux(ScreenManager):
             logger.error(f"Failed to get monitors: {e}")
             return [ScreenGeometry(0, 0, 1920, 1080, True)]
 
-    def _parse_xrandr_output(self, output: str) -> List[ScreenGeometry]:
+    def _parse_xrandr_output(self, output: str) -> list[ScreenGeometry]:
         """Parse xrandr output to extract monitor geometries."""
-        monitors: List[ScreenGeometry] = []
+        monitors: list[ScreenGeometry] = []
         for line in output.split("\n"):
             if " connected" in line:
                 match = re.search(r"(\d+)x(\d+)\+(\d+)\+(\d+)", line)
@@ -440,7 +455,7 @@ class ScreenManagerLinux(ScreenManager):
 class EVEPathResolverLinux(EVEPathResolver):
     """Linux EVE path resolution for Steam/Proton and Wine installations."""
 
-    def get_eve_settings_paths(self) -> List[Path]:
+    def get_eve_settings_paths(self) -> list[Path]:
         """Get candidate EVE settings paths for Linux."""
         home = Path.home()
 
@@ -499,7 +514,7 @@ class EVEPathResolverLinux(EVEPathResolver):
 
         return eve_steam_paths + legacy_paths
 
-    def get_eve_logs_paths(self) -> List[Path]:
+    def get_eve_logs_paths(self) -> list[Path]:
         """Get candidate EVE game logs paths for Linux."""
         home = Path.home()
         steam_base = home / ".steam" / "debian-installation" / "steamapps" / "compatdata"

--- a/src/argus_overview/platform/windows.py
+++ b/src/argus_overview/platform/windows.py
@@ -10,7 +10,7 @@ import threading
 import uuid
 from pathlib import Path
 from queue import Empty, Queue
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 from PIL import Image
 
@@ -60,7 +60,7 @@ class WindowManagerWindows(WindowManager):
         if not HAS_WIN32:
             logger.warning("pywin32 not available - window management disabled")
 
-    def get_window_list(self) -> List[Tuple[str, str]]:
+    def get_window_list(self) -> list[tuple[str, str]]:
         """Get list of all visible windows using EnumWindows."""
         if not HAS_WIN32:
             return []
@@ -79,12 +79,12 @@ class WindowManagerWindows(WindowManager):
 
         try:
             win32gui.EnumWindows(enum_callback, None)
-        except Exception as e:
-            logger.error(f"Failed to enumerate windows: {e}")
+        except OSError as e:
+            logger.warning("Failed to enumerate windows: %s", e)
 
         return windows
 
-    def get_eve_windows(self) -> List[Tuple[str, str]]:
+    def get_eve_windows(self) -> list[tuple[str, str]]:
         """Get list of EVE Online windows."""
         if not HAS_WIN32:
             return []
@@ -103,15 +103,15 @@ class WindowManagerWindows(WindowManager):
                             window_id = f"0x{hwnd:x}"
                             eve_windows.append((window_id, title))
                             break
-            except Exception:
-                pass
+            except OSError:
+                pass  # Window may have closed between visibility check and title read
 
             return True
 
         try:
             win32gui.EnumWindows(enum_callback, None)
-        except Exception as e:
-            logger.error(f"Failed to enumerate EVE windows: {e}")
+        except OSError as e:
+            logger.warning("Failed to enumerate EVE windows: %s", e)
 
         return eve_windows
 
@@ -180,7 +180,7 @@ class WindowManagerWindows(WindowManager):
             logger.warning("Failed to restore window %s: %s", window_id, e)
             return False
 
-    def get_focused_window(self) -> Optional[str]:
+    def get_focused_window(self) -> str | None:
         """Get the currently focused window ID."""
         if not HAS_WIN32:
             return None
@@ -215,7 +215,8 @@ class WindowManagerWindows(WindowManager):
         try:
             hwnd = int(window_id, 16)
             return win32gui.GetWindowText(hwnd)
-        except Exception:
+        except (OSError, ValueError) as e:
+            logger.debug("Failed to get window title for %s: %s", window_id, e)
             return "Unknown"
 
 
@@ -226,7 +227,7 @@ class WindowCaptureWindows(WindowCapture):
         self.max_workers = max_workers
         self.request_queue: Queue[Any] = Queue()
         self.result_queue: Queue[Any] = Queue()
-        self.workers: List[threading.Thread] = []
+        self.workers: list[threading.Thread] = []
         self._running = False
         self._window_mgr = WindowManagerWindows()
 
@@ -290,14 +291,14 @@ class WindowCaptureWindows(WindowCapture):
             logger.warning(f"Invalid window ID for capture: {window_id}")
             return ""
 
-    def get_result(self, timeout: float = 0.1) -> Optional[Tuple[str, str, Image.Image]]:
+    def get_result(self, timeout: float = 0.1) -> tuple[str, str, Image.Image] | None:
         """Get capture result if available."""
         try:
             return self.result_queue.get(timeout=timeout)
         except Empty:
             return None
 
-    def capture_window_sync(self, window_id: str, scale: float = 1.0) -> Optional[Image.Image]:
+    def capture_window_sync(self, window_id: str, scale: float = 1.0) -> Image.Image | None:
         """Synchronous window capture using Windows GDI."""
         if not HAS_WIN32:
             return None
@@ -327,36 +328,37 @@ class WindowCaptureWindows(WindowCapture):
             saveBitMap.CreateCompatibleBitmap(mfcDC, width, height)
             saveDC.SelectObject(saveBitMap)
 
-            # Copy window content to bitmap (PW_RENDERFULLCONTENT = 3)
-            windll.user32.PrintWindow(hwnd, saveDC.GetSafeHdc(), 3)
+            try:
+                # Copy window content to bitmap (PW_RENDERFULLCONTENT = 3)
+                windll.user32.PrintWindow(hwnd, saveDC.GetSafeHdc(), 3)
 
-            # Convert to PIL Image
-            bmpinfo = saveBitMap.GetInfo()
-            bmpstr = saveBitMap.GetBitmapBits(True)
+                # Convert to PIL Image
+                bmpinfo = saveBitMap.GetInfo()
+                bmpstr = saveBitMap.GetBitmapBits(True)
 
-            image = Image.frombuffer(
-                "RGB",
-                (bmpinfo["bmWidth"], bmpinfo["bmHeight"]),
-                bmpstr,
-                "raw",
-                "BGRX",
-                0,
-                1,
-            )
+                image = Image.frombuffer(
+                    "RGB",
+                    (bmpinfo["bmWidth"], bmpinfo["bmHeight"]),
+                    bmpstr,
+                    "raw",
+                    "BGRX",
+                    0,
+                    1,
+                )
 
-            # Scale if requested
-            if scale < 1.0:
-                new_width = int(width * scale)
-                new_height = int(height * scale)
-                image = image.resize((new_width, new_height), Image.LANCZOS)
+                # Scale if requested
+                if scale < 1.0:
+                    new_width = int(width * scale)
+                    new_height = int(height * scale)
+                    image = image.resize((new_width, new_height), Image.LANCZOS)
 
-            # Cleanup
-            win32gui.DeleteObject(saveBitMap.GetHandle())
-            saveDC.DeleteDC()
-            mfcDC.DeleteDC()
-            win32gui.ReleaseDC(hwnd, hwndDC)
-
-            return image
+                return image
+            finally:
+                # Always clean up GDI resources
+                win32gui.DeleteObject(saveBitMap.GetHandle())
+                saveDC.DeleteDC()
+                mfcDC.DeleteDC()
+                win32gui.ReleaseDC(hwnd, hwndDC)
 
         except Exception as e:
             logger.error(f"Failed to capture window {window_id}: {e}")
@@ -375,12 +377,12 @@ class ScreenManagerWindows(ScreenManager):
             return monitors[0]
         return ScreenGeometry(0, 0, 1920, 1080, True)
 
-    def get_all_monitors(self) -> List[ScreenGeometry]:
+    def get_all_monitors(self) -> list[ScreenGeometry]:
         """Get geometry for all connected monitors."""
         if not HAS_WIN32:
             return [ScreenGeometry(0, 0, 1920, 1080, True)]
 
-        monitors: List[ScreenGeometry] = []
+        monitors: list[ScreenGeometry] = []
 
         def monitor_enum_callback(hMonitor, hdcMonitor, lprcMonitor, dwData):
             # lprcMonitor is a tuple (left, top, right, bottom)
@@ -403,7 +405,7 @@ class ScreenManagerWindows(ScreenManager):
 class EVEPathResolverWindows(EVEPathResolver):
     """Windows EVE path resolution using LOCALAPPDATA."""
 
-    def get_eve_settings_paths(self) -> List[Path]:
+    def get_eve_settings_paths(self) -> list[Path]:
         """Get candidate EVE settings paths for Windows."""
         local_appdata = Path(os.environ.get("LOCALAPPDATA", ""))
 
@@ -411,7 +413,7 @@ class EVEPathResolverWindows(EVEPathResolver):
             local_appdata / "CCP" / "EVE",
         ]
 
-    def get_eve_logs_paths(self) -> List[Path]:
+    def get_eve_logs_paths(self) -> list[Path]:
         """Get candidate EVE game logs paths for Windows."""
         documents = Path(os.environ.get("USERPROFILE", "")) / "Documents"
 

--- a/src/argus_overview/ui/action_registry.py
+++ b/src/argus_overview/ui/action_registry.py
@@ -16,9 +16,10 @@ but must not create duplicate clickable UI.
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any
 
 
 class ActionScope(Enum):
@@ -97,10 +98,10 @@ class ActionSpec:
     scope: ActionScope
     primary_home: PrimaryHome
     tooltip: str = ""
-    shortcut: Optional[str] = None
-    icon: Optional[str] = None
-    handler_name: Optional[str] = None
-    enabled_when: Optional[str] = None  # Condition name, evaluated at runtime
+    shortcut: str | None = None
+    icon: str | None = None
+    handler_name: str | None = None
+    enabled_when: str | None = None  # Condition name, evaluated at runtime
     checkable: bool = False
 
 
@@ -118,9 +119,9 @@ class ActionRegistry:
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)
-        self._actions: Dict[str, ActionSpec] = {}
-        self._by_home: Dict[PrimaryHome, List[str]] = {home: [] for home in PrimaryHome}
-        self._handlers: Dict[str, Callable] = {}
+        self._actions: dict[str, ActionSpec] = {}
+        self._by_home: dict[PrimaryHome, list[str]] = {home: [] for home in PrimaryHome}
+        self._handlers: dict[str, Callable] = {}
 
         # Register all actions
         self._register_all_actions()
@@ -754,19 +755,19 @@ class ActionRegistry:
         self._by_home[action.primary_home].append(action.id)
         self.logger.debug(f"Registered action: {action.id} -> {action.primary_home.value}")
 
-    def get(self, action_id: str) -> Optional[ActionSpec]:
+    def get(self, action_id: str) -> ActionSpec | None:
         """Get action by ID"""
         return self._actions.get(action_id)
 
-    def get_by_home(self, home: PrimaryHome) -> List[ActionSpec]:
+    def get_by_home(self, home: PrimaryHome) -> list[ActionSpec]:
         """Get all actions for a specific home"""
         return [self._actions[aid] for aid in self._by_home.get(home, [])]
 
-    def get_by_scope(self, scope: ActionScope) -> List[ActionSpec]:
+    def get_by_scope(self, scope: ActionScope) -> list[ActionSpec]:
         """Get all actions for a specific scope"""
         return [a for a in self._actions.values() if a.scope == scope]
 
-    def all_actions(self) -> List[ActionSpec]:
+    def all_actions(self) -> list[ActionSpec]:
         """Get all registered actions"""
         return list(self._actions.values())
 
@@ -777,7 +778,7 @@ class ActionRegistry:
             return
         self._handlers[action_id] = handler
 
-    def get_handler(self, action_id: str) -> Optional[Callable]:
+    def get_handler(self, action_id: str) -> Callable | None:
         """Get bound handler for an action"""
         return self._handlers.get(action_id)
 
@@ -790,7 +791,7 @@ class ActionRegistry:
             self.logger.warning(f"No handler bound for action: {action_id}")
 
 
-def _count_actions_by_home_and_scope(actions, results: Dict[str, Any]):
+def _count_actions_by_home_and_scope(actions, results: dict[str, Any]):
     """Count actions by their primary home and scope."""
     for action in actions:
         home = action.primary_home.value
@@ -805,9 +806,9 @@ def _count_actions_by_home_and_scope(actions, results: Dict[str, Any]):
         results["by_scope"][scope].append(action.id)
 
 
-def _find_duplicate_homes(actions, results: Dict[str, Any]):
+def _find_duplicate_homes(actions, results: dict[str, Any]):
     """Find actions that appear in multiple primary homes."""
-    action_homes: Dict[str, Set[str]] = {}
+    action_homes: dict[str, set[str]] = {}
     for action in actions:
         if action.id not in action_homes:
             action_homes[action.id] = set()
@@ -819,7 +820,7 @@ def _find_duplicate_homes(actions, results: Dict[str, Any]):
             results["passed"] = False
 
 
-def audit_actions(registry: Optional[ActionRegistry] = None) -> Dict[str, Any]:
+def audit_actions(registry: ActionRegistry | None = None) -> dict[str, Any]:
     """
     Audit the action registry for duplicates and issues.
 
@@ -829,7 +830,7 @@ def audit_actions(registry: Optional[ActionRegistry] = None) -> Dict[str, Any]:
     if registry is None:
         registry = ActionRegistry.get_instance()
 
-    results: Dict[str, Any] = {
+    results: dict[str, Any] = {
         "total_actions": 0,
         "by_home": {},
         "by_scope": {},
@@ -852,7 +853,7 @@ def audit_actions(registry: Optional[ActionRegistry] = None) -> Dict[str, Any]:
     return results
 
 
-def print_audit_report(results: Optional[Dict] = None):
+def print_audit_report(results: dict | None = None):
     """Print a human-readable audit report"""
     if results is None:
         results = audit_actions()

--- a/src/argus_overview/ui/characters_teams_tab.py
+++ b/src/argus_overview/ui/characters_teams_tab.py
@@ -4,7 +4,6 @@ Implements character database, team building with drag-drop, and layout linking
 """
 
 import logging
-from typing import List, Optional
 
 from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtGui import QColor
@@ -127,7 +126,7 @@ class CharacterTable(QTableWidget):
         self.setSortingEnabled(True)
         self.logger.info(f"Populated table with {len(characters)} characters")
 
-    def update_character_status(self, char_name: str, window_id: Optional[str]):
+    def update_character_status(self, char_name: str, window_id: str | None):
         """
         Update character status in table
 
@@ -156,7 +155,7 @@ class CharacterTable(QTableWidget):
                 self.logger.debug(f"Updated status for {char_name}: {status}")
                 break
 
-    def get_selected_characters(self) -> List[str]:
+    def get_selected_characters(self) -> list[str]:
         """Get names of selected characters"""
         names = []
         for item in self.selectedItems():
@@ -174,7 +173,7 @@ class CharacterTable(QTableWidget):
 class CharacterDialog(QDialog):
     """Dialog for adding/editing characters"""
 
-    def __init__(self, character_manager, character: Optional[Character] = None, parent=None):
+    def __init__(self, character_manager, character: Character | None = None, parent=None):
         super().__init__(parent)
         self.logger = logging.getLogger(__name__)
         self.character_manager = character_manager
@@ -310,7 +309,7 @@ class TeamBuilder(QWidget):
         self.character_manager = character_manager
         self.layout_manager = layout_manager
 
-        self.current_team: Optional[Team] = None
+        self.current_team: Team | None = None
 
         self._setup_ui()
 
@@ -848,6 +847,6 @@ class CharactersTeamsTab(QWidget):
         self._refresh_teams()
         self.logger.info("Team modified")
 
-    def update_character_status(self, char_name: str, window_id: Optional[str]):
+    def update_character_status(self, char_name: str, window_id: str | None):
         """Update character status (called from main window)"""
         self.character_table.update_character_status(char_name, window_id)

--- a/src/argus_overview/ui/hotkey_edit.py
+++ b/src/argus_overview/ui/hotkey_edit.py
@@ -5,7 +5,6 @@ Allows setting any key combination including F13-F20, special keys, etc.
 """
 
 import logging
-from typing import Optional, Set
 
 from PySide6.QtCore import QTimer, Signal
 from PySide6.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QWidget
@@ -32,14 +31,14 @@ class HotkeyEdit(QWidget):
     recordingStarted = Signal()  # noqa: N815
     recordingStopped = Signal()  # noqa: N815
 
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
         self.logger = logging.getLogger(__name__)
 
         self._hotkey = ""
         self._recording = False
-        self._pressed_keys: Set[str] = set()
-        self._listener: Optional[keyboard.Listener] = None
+        self._pressed_keys: set[str] = set()
+        self._listener: keyboard.Listener | None = None
         self._timeout_timer = QTimer(self)
         self._timeout_timer.setSingleShot(True)
         self._timeout_timer.timeout.connect(self._stop_recording)
@@ -149,7 +148,7 @@ class HotkeyEdit(QWidget):
         if self._pressed_keys:
             self._finalize_hotkey()
 
-    def _key_to_string(self, key) -> Optional[str]:
+    def _key_to_string(self, key) -> str | None:
         """Convert pynput key to string format."""
         # Modifier keys
         if key == keyboard.Key.ctrl_l or key == keyboard.Key.ctrl_r or key == keyboard.Key.ctrl:

--- a/src/argus_overview/ui/hotkeys_tab.py
+++ b/src/argus_overview/ui/hotkeys_tab.py
@@ -4,7 +4,6 @@ Drag-and-drop interface for creating cycling groups and assigning hotkeys
 """
 
 import logging
-from typing import Dict, List, Optional
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QColor, QDragEnterEvent, QDropEvent
@@ -81,7 +80,7 @@ class CyclingGroupList(QListWidget):
             else:
                 event.ignore()
 
-    def dragMoveEvent(self, event):
+    def dragMoveEvent(self, event: QDragEnterEvent) -> None:
         event.acceptProposedAction()
 
     def dropEvent(self, event: QDropEvent):
@@ -107,7 +106,7 @@ class CyclingGroupList(QListWidget):
         else:
             event.ignore()
 
-    def get_members(self) -> List[str]:
+    def get_members(self) -> list[str]:
         """Get ordered list of member names"""
         return [self.item(i).text() for i in range(self.count())]
 
@@ -133,8 +132,8 @@ class HotkeysTab(QWidget):
         self.main_tab = main_tab  # Reference to main tab for getting active windows
 
         # Cycling groups data: {group_name: [char_names in order]}
-        self.cycling_groups: Dict[str, List[str]] = {}
-        self.current_group: Optional[str] = None
+        self.cycling_groups: dict[str, list[str]] = {}
+        self.current_group: str | None = None
 
         self._load_groups()
         self._setup_ui()
@@ -543,11 +542,11 @@ class HotkeysTab(QWidget):
         )
         self.logger.info(f"Saved hotkeys: forward={forward}, backward={backward}")
 
-    def get_cycling_group(self, name: str) -> List[str]:
+    def get_cycling_group(self, name: str) -> list[str]:
         """Get members of a cycling group"""
         return self.cycling_groups.get(name, [])
 
-    def get_all_groups(self) -> Dict[str, List[str]]:
+    def get_all_groups(self) -> dict[str, list[str]]:
         """Get all cycling groups"""
         return self.cycling_groups.copy()
 

--- a/src/argus_overview/ui/intel_tab.py
+++ b/src/argus_overview/ui/intel_tab.py
@@ -7,7 +7,6 @@ visual and audio alerts.
 
 import logging
 from pathlib import Path
-from typing import List, Optional
 
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtGui import QBrush, QColor, QFont
@@ -58,7 +57,7 @@ class IntelLogTable(QTableWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.logger = logging.getLogger(__name__)
-        self.reports: List[IntelReport] = []
+        self.reports: list[IntelReport] = []
 
         self._setup_table()
 
@@ -153,7 +152,7 @@ class IntelLogTable(QTableWidget):
             if row < len(self.reports):
                 self.entry_selected.emit(self.reports[row])
 
-    def get_selected_report(self) -> Optional[IntelReport]:
+    def get_selected_report(self) -> IntelReport | None:
         """Get currently selected report."""
         items = self.selectedItems()
         if items:

--- a/src/argus_overview/ui/layouts_tab.py
+++ b/src/argus_overview/ui/layouts_tab.py
@@ -6,7 +6,6 @@ Supports grid patterns, stacking, and custom positioning
 import logging
 import re
 import subprocess
-from typing import Dict, List, Tuple
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QColor
@@ -131,7 +130,7 @@ class ArrangementGrid(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.logger = logging.getLogger(__name__)
-        self.tiles: Dict[str, DraggableTile] = {}
+        self.tiles: dict[str, DraggableTile] = {}
         self.grid_rows = 3
         self.grid_cols = 4
 
@@ -225,7 +224,7 @@ class ArrangementGrid(QWidget):
         self.tiles[char_name] = tile
         self.grid_layout.addWidget(tile, row, col)
 
-    def get_arrangement(self) -> Dict[str, Tuple[int, int]]:
+    def get_arrangement(self) -> dict[str, tuple[int, int]]:
         """Get current arrangement as dict"""
         return {name: (tile.grid_row, tile.grid_col) for name, tile in self.tiles.items()}
 
@@ -269,8 +268,8 @@ class GridApplier:
 
     def apply_arrangement(
         self,
-        arrangement: Dict[str, Tuple[int, int]],
-        window_map: Dict[str, str],
+        arrangement: dict[str, tuple[int, int]],
+        window_map: dict[str, str],
         screen: ScreenGeometry,
         grid_rows: int,
         grid_cols: int,
@@ -371,7 +370,7 @@ class LayoutsTab(QWidget):
         self.logger = logging.getLogger(__name__)
 
         self.grid_applier = GridApplier(layout_manager)
-        self.cycling_groups: Dict[str, List[str]] = {}
+        self.cycling_groups: dict[str, list[str]] = {}
 
         self._load_groups()
         self._setup_ui()

--- a/src/argus_overview/ui/main_tab.py
+++ b/src/argus_overview/ui/main_tab.py
@@ -8,7 +8,6 @@ v2.3: Merged layouts functionality - group-based window arrangement
 import logging
 import threading
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
 
 from PIL import Image
 from PySide6.QtCore import (
@@ -33,6 +32,7 @@ from PySide6.QtWidgets import (
     QInputDialog,
     QLabel,
     QLayout,
+    QLayoutItem,
     QLineEdit,
     QListWidget,
     QListWidgetItem,
@@ -56,52 +56,52 @@ class FlowLayout(QLayout):
     when the available width is exceeded. Perfect for thumbnail grids.
     """
 
-    def __init__(self, parent=None, margin=10, spacing=10):
+    def __init__(self, parent: QWidget | None = None, margin: int = 10, spacing: int = 10):
         super().__init__(parent)
-        self._item_list = []
+        self._item_list: list[QLayoutItem] = []
         self._margin = margin
         self._spacing = spacing
 
-    def addItem(self, item):
+    def addItem(self, item: QLayoutItem) -> None:
         self._item_list.append(item)
 
-    def count(self):
+    def count(self) -> int:
         return len(self._item_list)
 
-    def itemAt(self, index):
+    def itemAt(self, index: int) -> QLayoutItem | None:
         if 0 <= index < len(self._item_list):
             return self._item_list[index]
         return None
 
-    def takeAt(self, index):
+    def takeAt(self, index: int) -> QLayoutItem | None:
         if 0 <= index < len(self._item_list):
             return self._item_list.pop(index)
         return None
 
-    def expandingDirections(self):
+    def expandingDirections(self) -> Qt.Orientation:
         return Qt.Orientation(0)
 
-    def hasHeightForWidth(self):
+    def hasHeightForWidth(self) -> bool:
         return True
 
-    def heightForWidth(self, width):
+    def heightForWidth(self, width: int) -> int:
         return self._do_layout(QRect(0, 0, width, 0), test_only=True)
 
-    def setGeometry(self, rect):
+    def setGeometry(self, rect: QRect) -> None:
         super().setGeometry(rect)
         self._do_layout(rect, test_only=False)
 
-    def sizeHint(self):
+    def sizeHint(self) -> QSize:
         return self.minimumSize()
 
-    def minimumSize(self):
+    def minimumSize(self) -> QSize:
         size = QSize()
         for item in self._item_list:
             size = size.expandedTo(item.minimumSize())
         size += QSize(2 * self._margin, 2 * self._margin)
         return size
 
-    def _do_layout(self, rect, test_only):
+    def _do_layout(self, rect: QRect, test_only: bool) -> int:
         x = rect.x() + self._margin
         y = rect.y() + self._margin
         line_height = 0
@@ -138,7 +138,7 @@ class FlowLayout(QLayout):
 
         return y + line_height - rect.y() + self._margin
 
-    def _center_row(self, row_items, rect, y, line_height):
+    def _center_row(self, row_items: list, rect: QRect, y: int, line_height: int) -> None:
         """Center items in a row"""
         if not row_items:
             return
@@ -184,7 +184,7 @@ PATTERN_POSITIONS = {
 }
 
 
-def get_pattern_positions(pattern: str, count: int, grid_cols: int = 4) -> List[Tuple[int, int]]:
+def get_pattern_positions(pattern: str, count: int, grid_cols: int = 4) -> list[tuple[int, int]]:
     """Get grid positions for a layout pattern.
 
     Args:
@@ -274,7 +274,7 @@ class ArrangementGrid(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.logger = logging.getLogger(__name__)
-        self.tiles: Dict[str, DraggableTile] = {}
+        self.tiles: dict[str, DraggableTile] = {}
         self.grid_rows = 2
         self.grid_cols = 3
 
@@ -363,7 +363,7 @@ class ArrangementGrid(QWidget):
         self.tiles[char_name] = tile
         self.grid_layout.addWidget(tile, row, col)
 
-    def get_arrangement(self) -> Dict[str, Tuple[int, int]]:
+    def get_arrangement(self) -> dict[str, tuple[int, int]]:
         return {name: (tile.grid_row, tile.grid_col) for name, tile in self.tiles.items()}
 
     def auto_arrange_grid(self, pattern: str):
@@ -452,8 +452,8 @@ class GridApplier:
 
     def apply_arrangement(
         self,
-        arrangement: Dict[str, Tuple[int, int]],
-        window_map: Dict[str, str],
+        arrangement: dict[str, tuple[int, int]],
+        window_map: dict[str, str],
         screen: ScreenGeometry,
         grid_rows: int,
         grid_cols: int,
@@ -588,11 +588,11 @@ class WindowPreviewWidget(QWidget):
         self.settings_manager = settings_manager
 
         # State
-        self.current_pixmap: Optional[QPixmap] = None
+        self.current_pixmap: QPixmap | None = None
         self.zoom_factor = 0.3  # 30% scale
 
         # v2.2 State
-        self.custom_label: Optional[str] = None
+        self.custom_label: str | None = None
         self.session_start: datetime = datetime.now()
         self.last_activity: datetime = datetime.now()
         self.is_focused: bool = False
@@ -723,7 +723,7 @@ class WindowPreviewWidget(QWidget):
         else:
             self.timer_label.setText(f"{minutes}m")
 
-    def set_custom_label(self, label: Optional[str]):
+    def set_custom_label(self, label: str | None):
         """
         Set a custom label for this thumbnail
 
@@ -941,8 +941,8 @@ class WindowManager:
         self.settings_manager = settings_manager
 
         # State
-        self.preview_frames: Dict[str, WindowPreviewWidget] = {}
-        self.pending_requests: Dict[str, str] = {}  # request_id -> window_id
+        self.preview_frames: dict[str, WindowPreviewWidget] = {}
+        self.pending_requests: dict[str, str] = {}  # request_id -> window_id
         self._pending_lock = threading.Lock()  # Protect pending_requests access
         # Read refresh rate from settings (default 5 FPS for efficiency)
         if settings_manager:
@@ -979,7 +979,7 @@ class WindowManager:
             self.stop_capture_loop()
             self.start_capture_loop()
 
-    def add_window(self, window_id: str, character_name: str) -> Optional[WindowPreviewWidget]:
+    def add_window(self, window_id: str, character_name: str) -> WindowPreviewWidget | None:
         """
         Add window to preview
 
@@ -1106,7 +1106,7 @@ class MainTab(QWidget):
         self._refresh_sources_timer.timeout.connect(self._do_refresh_layout_sources)
 
         self.grid_applier = GridApplier()
-        self.cycling_groups: Dict[str, List[str]] = {}
+        self.cycling_groups: dict[str, list[str]] = {}
         self._load_cycling_groups()
 
         # Create window manager

--- a/src/argus_overview/ui/main_window_v21.py
+++ b/src/argus_overview/ui/main_window_v21.py
@@ -44,7 +44,6 @@ Lifecycle:
 
 import logging
 from pathlib import Path
-from typing import Optional
 
 from PySide6.QtCore import Qt, Slot
 from PySide6.QtGui import QCloseEvent, QIcon
@@ -271,7 +270,7 @@ class MainWindowV21(QMainWindow):
 
         return members
 
-    def _get_window_id_for_character(self, char_name: str) -> Optional[str]:
+    def _get_window_id_for_character(self, char_name: str) -> str | None:
         """Get window ID for a character name"""
         if hasattr(self, "main_tab") and hasattr(self.main_tab, "window_manager"):
             for window_id, frame in self.main_tab.window_manager.preview_frames.items():

--- a/src/argus_overview/ui/menu_builder.py
+++ b/src/argus_overview/ui/menu_builder.py
@@ -7,7 +7,7 @@ source of truth.
 """
 
 import logging
-from typing import Callable, Dict, List, Optional
+from collections.abc import Callable
 
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QPushButton
@@ -45,7 +45,7 @@ class MenuBuilder:
         tray_menu = builder.build_tray_menu(parent_widget, handlers)
     """
 
-    def __init__(self, registry: Optional[ActionRegistry] = None):
+    def __init__(self, registry: ActionRegistry | None = None):
         self.logger = logging.getLogger(__name__)
         self.registry = registry or ActionRegistry.get_instance()
 
@@ -53,8 +53,8 @@ class MenuBuilder:
         self,
         home: PrimaryHome,
         parent=None,
-        handlers: Optional[Dict[str, Callable]] = None,
-        menu: Optional[QMenu] = None,
+        handlers: dict[str, Callable] | None = None,
+        menu: QMenu | None = None,
     ) -> QMenu:
         """
         Build a QMenu from actions registered for a specific home.
@@ -83,10 +83,10 @@ class MenuBuilder:
     def build_tray_menu(
         self,
         parent=None,
-        handlers: Optional[Dict[str, Callable]] = None,
-        profile_handler: Optional[Callable] = None,
-        profiles: Optional[List[str]] = None,
-        current_profile: Optional[str] = None,
+        handlers: dict[str, Callable] | None = None,
+        profile_handler: Callable | None = None,
+        profiles: list[str] | None = None,
+        current_profile: str | None = None,
     ) -> QMenu:
         """
         Build the system tray context menu.
@@ -143,7 +143,7 @@ class MenuBuilder:
     def build_help_menu(
         self,
         parent=None,
-        handlers: Optional[Dict[str, Callable]] = None,
+        handlers: dict[str, Callable] | None = None,
     ) -> QMenu:
         """
         Build the Help menu for the menu bar.
@@ -183,7 +183,7 @@ class MenuBuilder:
         self,
         spec: ActionSpec,
         parent=None,
-        handler: Optional[Callable] = None,
+        handler: Callable | None = None,
     ) -> QAction:
         """
         Create a QAction from an ActionSpec.
@@ -217,9 +217,9 @@ class MenuBuilder:
     def _populate_profiles_menu(
         self,
         menu: QMenu,
-        profiles: List[str],
-        current_profile: Optional[str],
-        handler: Optional[Callable],
+        profiles: list[str],
+        current_profile: str | None,
+        handler: Callable | None,
     ):
         """
         Populate profiles submenu.
@@ -255,9 +255,9 @@ class MenuBuilder:
 
 def build_toolbar_actions(
     home: PrimaryHome,
-    handlers: Optional[Dict[str, Callable]] = None,
-    registry: Optional[ActionRegistry] = None,
-) -> List[QAction]:
+    handlers: dict[str, Callable] | None = None,
+    registry: ActionRegistry | None = None,
+) -> list[QAction]:
     """
     Build a list of QActions for a toolbar.
 
@@ -286,12 +286,12 @@ class ContextMenuBuilder:
     Context menus are for object-level actions (right-click on items).
     """
 
-    def __init__(self, registry: Optional[ActionRegistry] = None):
+    def __init__(self, registry: ActionRegistry | None = None):
         self.logger = logging.getLogger(__name__)
         self.registry = registry or ActionRegistry.get_instance()
 
     def _build_zoom_submenu(
-        self, menu: QMenu, zoom_handler: Optional[Callable], current_zoom: float
+        self, menu: QMenu, zoom_handler: Callable | None, current_zoom: float
     ):
         """Build the zoom level submenu with checkmark for current level."""
         zoom_menu = menu.addMenu("Zoom Level")
@@ -308,7 +308,7 @@ class ContextMenuBuilder:
                 zoom_action.triggered.connect(make_zoom_callback())
             zoom_menu.addAction(zoom_action)
 
-    def _add_registry_action(self, menu: QMenu, action_id: str, handlers: Dict[str, Callable]):
+    def _add_registry_action(self, menu: QMenu, action_id: str, handlers: dict[str, Callable]):
         """Add an action from registry to the menu."""
         spec = self.registry.get(action_id)
         if spec:
@@ -323,8 +323,8 @@ class ContextMenuBuilder:
 
     def build_window_context_menu(
         self,
-        handlers: Dict[str, Callable],
-        zoom_handler: Optional[Callable] = None,
+        handlers: dict[str, Callable],
+        zoom_handler: Callable | None = None,
         current_zoom: float = 0.3,
         parent=None,
     ) -> QMenu:
@@ -406,17 +406,17 @@ class ToolbarBuilder:
     SUCCESS_ACTIONS = {"scan_eve_folder", "new_group", "load_active_windows", "new_team"}
     DANGER_ACTIONS = {"delete_group", "delete_character", "remove_all_windows"}
 
-    def __init__(self, registry: Optional[ActionRegistry] = None):
+    def __init__(self, registry: ActionRegistry | None = None):
         self.logger = logging.getLogger(__name__)
         self.registry = registry or ActionRegistry.get_instance()
 
     def build_toolbar_buttons(
         self,
         home: PrimaryHome,
-        handlers: Dict[str, Callable],
-        action_order: Optional[List[str]] = None,
+        handlers: dict[str, Callable],
+        action_order: list[str] | None = None,
         parent=None,
-    ) -> Dict[str, QPushButton]:
+    ) -> dict[str, QPushButton]:
         """
         Build toolbar buttons from the registry.
 
@@ -472,9 +472,9 @@ class ToolbarBuilder:
     def create_button(
         self,
         action_id: str,
-        handler: Optional[Callable] = None,
+        handler: Callable | None = None,
         parent=None,
-    ) -> Optional[QPushButton]:
+    ) -> QPushButton | None:
         """
         Create a single button from a registry action.
 

--- a/src/argus_overview/ui/settings_manager.py
+++ b/src/argus_overview/ui/settings_manager.py
@@ -8,7 +8,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 class SettingsManager:
@@ -97,7 +97,7 @@ class SettingsManager:
         },
     }
 
-    def __init__(self, config_dir: Optional[Path] = None):
+    def __init__(self, config_dir: Path | None = None):
         """
         Initialize SettingsManager
 
@@ -113,15 +113,15 @@ class SettingsManager:
         self.config_dir.mkdir(parents=True, exist_ok=True)
 
         self.settings_file = self.config_dir / "settings.json"
-        self.settings: Dict = {}
+        self.settings: dict = {}
 
         # Runtime state (not persisted)
-        self._last_activated_window: Optional[str] = None
+        self._last_activated_window: str | None = None
 
         # Load settings or create defaults
         self.load_settings()
 
-    def load_settings(self) -> Dict:
+    def load_settings(self) -> dict:
         """
         Load settings from JSON file
 
@@ -139,16 +139,19 @@ class SettingsManager:
                 self.logger.info(f"Loaded settings from {self.settings_file}")
                 return self.settings
 
-            except Exception as e:
-                self.logger.error(f"Failed to load settings: {e}")
-                self.logger.info("Using default settings")
+            except json.JSONDecodeError as e:
+                self.logger.error("Settings file is corrupted (%s): %s", self.settings_file, e)
+                self.logger.info("Falling back to default settings")
+            except OSError as e:
+                self.logger.error("Failed to read settings file (%s): %s", self.settings_file, e)
+                self.logger.info("Falling back to default settings")
 
         # Use defaults if file doesn't exist or load failed
         self.settings = copy.deepcopy(self.DEFAULT_SETTINGS)
         self.save_settings(self.settings)
         return self.settings
 
-    def save_settings(self, settings: Optional[Dict] = None) -> bool:
+    def save_settings(self, settings: dict | None = None) -> bool:
         """
         Save settings to JSON file
 
@@ -308,7 +311,7 @@ class SettingsManager:
             self.logger.error(f"Failed to import settings: {e}")
             return False
 
-    def _merge_settings(self, base: Dict, overlay: Dict) -> Dict:
+    def _merge_settings(self, base: dict, overlay: dict) -> dict:
         """
         Recursively merge overlay settings into base settings
         Preserves structure from base, updates values from overlay
@@ -328,7 +331,7 @@ class SettingsManager:
 
         return base
 
-    def get_all(self) -> Dict:
+    def get_all(self) -> dict:
         """
         Get all settings
 
@@ -363,10 +366,10 @@ class SettingsManager:
             self.logger.error(f"Settings validation failed: {e}")
             return False
 
-    def get_last_activated_window(self) -> Optional[str]:
+    def get_last_activated_window(self) -> str | None:
         """Get the last activated EVE window ID (runtime state, not persisted)"""
         return self._last_activated_window
 
-    def set_last_activated_window(self, window_id: Optional[str]) -> None:
+    def set_last_activated_window(self, window_id: str | None) -> None:
         """Set the last activated EVE window ID (runtime state, not persisted)"""
         self._last_activated_window = window_id

--- a/src/argus_overview/ui/themes.py
+++ b/src/argus_overview/ui/themes.py
@@ -5,7 +5,6 @@ v2.2 Feature: Dark, Light, EVE, and Custom themes
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, Optional
 
 from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import QApplication
@@ -56,7 +55,7 @@ class Theme:
         self.name = name
         self.colors = colors
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Serialize theme to dict"""
         return {
             "name": self.name,
@@ -82,7 +81,7 @@ class Theme:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict) -> "Theme":
+    def from_dict(cls, data: dict) -> "Theme":
         """Create theme from dict"""
         colors = ThemeColors(**data.get("colors", {}))
         return cls(data.get("name", "custom"), colors)
@@ -178,10 +177,10 @@ class ThemeManager:
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)
-        self.current_theme: Optional[Theme] = None
-        self.custom_themes: Dict[str, Theme] = {}
+        self.current_theme: Theme | None = None
+        self.custom_themes: dict[str, Theme] = {}
 
-    def get_available_themes(self) -> Dict[str, str]:
+    def get_available_themes(self) -> dict[str, str]:
         """
         Get list of available theme names.
 
@@ -199,7 +198,7 @@ class ThemeManager:
 
         return themes
 
-    def apply_theme(self, theme_name: str, app: Optional[QApplication] = None) -> bool:
+    def apply_theme(self, theme_name: str, app: QApplication | None = None) -> bool:
         """
         Apply a theme to the application.
 
@@ -287,7 +286,7 @@ class ThemeManager:
         self.custom_themes[theme.name] = theme
         self.logger.info(f"Registered custom theme: {theme.name}")
 
-    def get_current_theme(self) -> Optional[Theme]:
+    def get_current_theme(self) -> Theme | None:
         """Get currently applied theme"""
         return self.current_theme
 
@@ -297,7 +296,7 @@ class ThemeManager:
             return self.current_theme.colors.accent
         return DARK_THEME.colors.accent
 
-    def get_alert_colors(self) -> Dict[str, str]:
+    def get_alert_colors(self) -> dict[str, str]:
         """Get current theme's alert colors"""
         if self.current_theme:
             return {
@@ -313,7 +312,7 @@ class ThemeManager:
 
 
 # Global theme manager instance
-_theme_manager: Optional[ThemeManager] = None
+_theme_manager: ThemeManager | None = None
 
 
 def get_theme_manager() -> ThemeManager:

--- a/src/argus_overview/ui/tray.py
+++ b/src/argus_overview/ui/tray.py
@@ -5,7 +5,6 @@ v2.4: Refactored to use ActionRegistry for menu construction
 """
 
 import logging
-from typing import List, Optional
 
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtGui import QColor, QFont, QIcon, QPainter, QPixmap
@@ -47,8 +46,8 @@ class SystemTray(QObject):
 
         # State
         self._visible = True
-        self._profiles: List[str] = []
-        self._current_profile: Optional[str] = None
+        self._profiles: list[str] = []
+        self._current_profile: str | None = None
 
         # Action registry and menu builder
         self.registry = ActionRegistry.get_instance()
@@ -181,7 +180,7 @@ class SystemTray(QObject):
         self.tray_icon.hide()
         self.logger.debug("Tray icon hidden")
 
-    def set_profiles(self, profiles: List[str], current: Optional[str] = None):
+    def set_profiles(self, profiles: list[str], current: str | None = None):
         """
         Update available profiles
 

--- a/src/argus_overview/utils/constants.py
+++ b/src/argus_overview/utils/constants.py
@@ -8,6 +8,11 @@ TIMEOUT_SHORT = 1  # Quick operations (getwindowfocus)
 TIMEOUT_MEDIUM = 2  # Window move/resize operations
 TIMEOUT_LONG = 5  # Slower operations (wmctrl -l)
 
+# X11 subprocess retry defaults
+X11_MAX_ATTEMPTS = 3
+X11_BACKOFF_SECONDS = 0.15
+X11_DEFAULT_TIMEOUT = 2.0
+
 # Window capture settings
 DEFAULT_CAPTURE_WORKERS = 4
 DEFAULT_REFRESH_RATE = 30  # FPS

--- a/src/argus_overview/utils/display_server.py
+++ b/src/argus_overview/utils/display_server.py
@@ -9,7 +9,6 @@ import os
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +29,8 @@ class DisplayInfo:
     server: DisplayServer
     has_x11_access: bool  # Can use X11 tools (wmctrl, xdotool, etc.)
     session_type: str  # Raw XDG_SESSION_TYPE value
-    wayland_display: Optional[str]  # WAYLAND_DISPLAY if set
-    x11_display: Optional[str]  # DISPLAY if set
+    wayland_display: str | None  # WAYLAND_DISPLAY if set
+    x11_display: str | None  # DISPLAY if set
 
 
 def detect_display_server() -> DisplayInfo:

--- a/src/argus_overview/utils/screen.py
+++ b/src/argus_overview/utils/screen.py
@@ -4,7 +4,6 @@ v3.0: Cross-platform support via platform abstraction layer.
 """
 
 import logging
-from typing import List
 
 from argus_overview.platform import get_screen_manager
 from argus_overview.platform.base import ScreenGeometry
@@ -30,7 +29,7 @@ def get_screen_geometry(monitor: int = 0) -> ScreenGeometry:
     return screen_mgr.get_screen_geometry(monitor)
 
 
-def get_all_monitors() -> List[ScreenGeometry]:
+def get_all_monitors() -> list[ScreenGeometry]:
     """Get geometry for all connected monitors.
 
     Uses platform-specific methods (xrandr on Linux, EnumDisplayMonitors on Windows).

--- a/src/argus_overview/utils/window_utils.py
+++ b/src/argus_overview/utils/window_utils.py
@@ -5,7 +5,6 @@ This module now serves as a compatibility layer, delegating to platform implemen
 """
 
 import logging
-from typing import Optional
 
 from argus_overview.platform import get_window_manager, is_linux
 
@@ -73,7 +72,7 @@ def activate_window(window_id: str, timeout: float = 2.0) -> bool:
     return _get_window_mgr().activate_window(window_id, timeout)
 
 
-def get_focused_window() -> Optional[str]:
+def get_focused_window() -> str | None:
     """Get the currently focused window ID.
 
     Returns:

--- a/src/main.py
+++ b/src/main.py
@@ -34,7 +34,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Optional, TextIO
+from typing import TextIO
 
 # Platform-specific imports for single-instance locking
 if sys.platform == "win32":
@@ -63,7 +63,7 @@ class SingleInstance:
 
     def __init__(self, app_name: str = "argus-overview"):
         self.app_name = app_name
-        self.lock_file: Optional[TextIO] = None
+        self.lock_file: TextIO | None = None
 
         # Platform-specific lock file location
         if sys.platform == "win32":
@@ -95,8 +95,8 @@ class SingleInstance:
                 self.lock_file.write(str(os.getpid()))
                 self.lock_file.flush()
                 return True
-            except Exception:
-                # Lock failed or other error - clean up file handle
+            except OSError:
+                # Lock failed - clean up file handle
                 self.lock_file.close()
                 self.lock_file = None
                 raise


### PR DESCRIPTION
- Fix ruff target-version mismatch (py38 -> py310) to match requires-python
- Add threading.Lock to wmctrl cache to prevent race conditions
- Narrow over-broad exception handlers to specific types (OSError, SubprocessError, etc.)
- Add try/finally for GDI resource cleanup in Windows capture to prevent leaks
- Add return type hints to FlowLayout methods and other missing annotations
- Set observer thread as daemon in config_watcher for clean shutdown
- Improve settings_manager error logging to distinguish JSON corruption vs IO errors
- Centralize X11 retry constants in utils/constants.py
- Normalize logging levels (warning vs error) across platform modules
- Modernize type annotations to Python 3.10+ syntax (ruff --fix)

https://claude.ai/code/session_01AQLRPRwVS8rLvc8SN6v4iZ