### PR TITLE
feat(ui): character status dock with per-chip threat state

### DIFF
--- a/src/argus_overview/ui/main_tab.py
+++ b/src/argus_overview/ui/main_tab.py
@@ -1351,6 +1351,18 @@ class MainTab(QWidget):
         layout_controls = self._create_layout_controls()
         layout.addWidget(layout_controls)
 
+        # PR2: Character status dock — chip strip with per-character system
+        # + threat dot. Clicking a chip focuses the matching window.
+        # Parent is set when the dock is added to the layout below.
+        from argus_overview.ui.status_dock import StatusDock
+
+        self.status_dock = StatusDock()
+        self.status_dock.chip_clicked.connect(self._on_window_activated)
+        sm = getattr(self, "settings_manager", None)
+        show_dock = sm.get("thumbnails.show_status_dock", True) if sm else True
+        self.status_dock.setVisible(show_dock)
+        layout.addWidget(self.status_dock)
+
         # Scroll area for preview frames
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -1368,6 +1380,16 @@ class MainTab(QWidget):
         # Status bar
         status_bar = self._create_status_bar()
         layout.addWidget(status_bar)
+
+    def _sync_status_dock(self) -> None:
+        """Mirror window_manager.preview_frames into the status dock."""
+        if not hasattr(self, "status_dock") or self.status_dock is None:
+            return
+        desired: dict[str, str] = {
+            wid: getattr(frame, "character_name", wid)
+            for wid, frame in self.window_manager.preview_frames.items()
+        }
+        self.status_dock.sync_from_window_ids(desired)
 
     def _create_toolbar(self) -> QWidget:
         """Create toolbar using ActionRegistry (v2.3)"""
@@ -1754,6 +1776,7 @@ class MainTab(QWidget):
             self.status_label.setText("No new EVE windows found")
 
         self._update_status()
+        self._sync_status_dock()
 
     def _toggle_lock(self):
         """Toggle thumbnail position lock"""
@@ -1849,6 +1872,7 @@ class MainTab(QWidget):
                 self._on_window_removed, Qt.ConnectionType.UniqueConnection
             )
             self.preview_layout.addWidget(frame)
+            self._sync_status_dock()
             return True
         return False
 
@@ -1957,6 +1981,7 @@ class MainTab(QWidget):
             frame.session_timer.stop()
         self.window_manager.remove_window(window_id)
         self._update_status()
+        self._sync_status_dock()
 
     def _remove_all_windows(self):
         """Remove all windows from preview"""
@@ -1977,6 +2002,7 @@ class MainTab(QWidget):
                 self.window_manager.remove_window(window_id)
 
             self._update_status()
+            self._sync_status_dock()
 
     def minimize_inactive_windows(self):
         """Toggle auto-minimize mode - when enabled, cycling minimizes previous window"""

--- a/src/argus_overview/ui/main_window_v21.py
+++ b/src/argus_overview/ui/main_window_v21.py
@@ -659,13 +659,16 @@ class MainWindowV21(QMainWindow):
         if not isinstance(report, IntelReport):
             return
 
-        # Fan out threat state to preview frames once per report
+        # Fan out threat state to preview frames + status dock once per report
         # (filter on VISUAL_BORDER so we only trigger on a single AlertType
         # emission per report, not on every type the dispatcher fires).
         if alert_type == AlertType.VISUAL_BORDER and hasattr(self, "main_tab"):
             window_manager = getattr(self.main_tab, "window_manager", None)
             if window_manager is not None and hasattr(window_manager, "apply_threat_state"):
                 window_manager.apply_threat_state(report.threat_level, report.system)
+            status_dock = getattr(self.main_tab, "status_dock", None)
+            if status_dock is not None and hasattr(status_dock, "set_threat_state"):
+                status_dock.set_threat_state(report.threat_level, report.system)
 
         # Show tray notification for critical alerts
         if report.threat_level.value == "critical":

--- a/src/argus_overview/ui/status_dock.py
+++ b/src/argus_overview/ui/status_dock.py
@@ -1,0 +1,323 @@
+"""
+Character Status Dock — horizontal strip of character chips.
+
+Each chip surfaces per-character state that EVE-O Preview cannot:
+character avatar (initials in an accent color), system name, and a
+threat-tint dot driven by the same intel pipeline that tints preview
+borders. Click a chip to focus the matching window.
+
+PR2 of the intel-aware UI uplift. Pairs with WindowPreviewWidget's
+threat-tint border (PR1) so glanceable threat state is visible whether
+you're looking at a thumbnail grid or the dock.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QBrush, QColor, QPainter, QPen
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from argus_overview.intel.parser import ThreatLevel
+from argus_overview.ui.main_tab import THREAT_BORDER_COLORS
+
+# Stable accent palette — same hue per character across sessions
+CHIP_ACCENT_COLORS: list[tuple[int, int, int]] = [
+    (255, 100, 100),
+    (100, 255, 100),
+    (100, 150, 255),
+    (255, 200, 80),
+    (220, 120, 220),
+    (100, 220, 220),
+    (255, 165, 60),
+    (170, 130, 255),
+]
+
+
+def accent_for(name: str) -> QColor:
+    """Deterministic accent color for a character name."""
+    r, g, b = CHIP_ACCENT_COLORS[abs(hash(name)) % len(CHIP_ACCENT_COLORS)]
+    return QColor(r, g, b)
+
+
+def _initials(name: str) -> str:
+    parts = [p for p in name.replace("_", " ").split() if p]
+    if not parts:
+        return "?"
+    if len(parts) == 1:
+        return parts[0][:2].upper()
+    return (parts[0][0] + parts[-1][0]).upper()
+
+
+class CharacterChip(QFrame):
+    """
+    A single chip in the StatusDock.
+
+    Layout (left to right):
+      [ avatar 28x28 ] [ name ]      [ system pill ]   [ threat dot ]
+    """
+
+    clicked = Signal(str)  # window_id
+
+    AVATAR_SIZE = 28
+    DOT_SIZE = 10
+
+    def __init__(
+        self,
+        window_id: str,
+        character_name: str,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.window_id = window_id
+        self.character_name = character_name
+        self._accent: QColor = accent_for(character_name)
+        self._system: str | None = None
+        self._threat_level: ThreatLevel | None = None
+        self._threat_alpha: float = 0.0
+
+        self.setFixedHeight(40)
+        self.setMinimumWidth(160)
+        self.setMaximumWidth(260)
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._apply_base_style()
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(6, 4, 8, 4)
+        layout.setSpacing(8)
+
+        # Avatar — a fixed-size frame painted with initials in the accent color
+        self._avatar = QLabel(_initials(character_name))
+        self._avatar.setFixedSize(self.AVATAR_SIZE, self.AVATAR_SIZE)
+        self._avatar.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._update_avatar_style()
+        layout.addWidget(self._avatar)
+
+        # Name label (primary, bold)
+        self._name_label = QLabel(character_name)
+        self._name_label.setStyleSheet("font-weight: bold; font-size: 10pt;")
+        self._name_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        layout.addWidget(self._name_label)
+
+        # System label (secondary)
+        self._system_label = QLabel("—")
+        self._system_label.setStyleSheet("color: #aaa; font-size: 9pt;")
+        self._system_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(self._system_label)
+
+        # Threat dot is painted in paintEvent (no widget needed — keeps chip compact)
+
+        self.setToolTip(self._tooltip_text())
+
+    # ----- styling helpers --------------------------------------------------
+    def _apply_base_style(self) -> None:
+        self.setStyleSheet(
+            """
+            CharacterChip {
+                background-color: #2b2b2b;
+                border: 1px solid #444;
+                border-radius: 6px;
+            }
+            CharacterChip:hover {
+                background-color: #353535;
+                border-color: #6a6a6a;
+            }
+            """
+        )
+
+    def _update_avatar_style(self) -> None:
+        a = self._accent
+        darker = a.darker(160)
+        # luminance-based contrast for the initials text
+        luminance = (a.red() * 299 + a.green() * 587 + a.blue() * 114) / 1000
+        text_color = "#0f0f0f" if luminance > 140 else "#f5f5f5"
+        self._avatar.setStyleSheet(
+            f"""
+            background-color: {a.name()};
+            border: 1px solid {darker.name()};
+            border-radius: {self.AVATAR_SIZE // 2}px;
+            color: {text_color};
+            font-weight: bold;
+            font-size: 10pt;
+            """
+        )
+
+    def _tooltip_text(self) -> str:
+        parts = [self.character_name]
+        if self._system:
+            parts.append(f"System: {self._system}")
+        if self._threat_level is not None:
+            parts.append(f"Threat: {self._threat_level.value}")
+        parts.append("Click to focus window")
+        return "\n".join(parts)
+
+    # ----- public API -------------------------------------------------------
+    def set_system(self, system: str | None) -> None:
+        self._system = system
+        self._system_label.setText(system or "—")
+        self.setToolTip(self._tooltip_text())
+
+    def set_threat_state(
+        self, level: ThreatLevel | None, system: str | None = None, alpha: float = 1.0
+    ) -> None:
+        if level is None or level == ThreatLevel.CLEAR:
+            self._threat_level = None
+            self._threat_alpha = 0.0
+        else:
+            self._threat_level = level
+            self._threat_alpha = max(0.0, min(1.0, alpha))
+        if system is not None:
+            self.set_system(system)
+        else:
+            self.setToolTip(self._tooltip_text())
+        self.update()
+
+    # ----- events -----------------------------------------------------------
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit(self.window_id)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        if self._threat_level is None or self._threat_alpha <= 0.0:
+            return
+
+        painter = QPainter(self)
+        try:
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+            r, g, b = THREAT_BORDER_COLORS.get(self._threat_level, (255, 255, 255))
+            alpha = max(0, min(255, int(230 * self._threat_alpha)))
+            color = QColor(r, g, b, alpha)
+            painter.setPen(QPen(color.darker(140), 1))
+            painter.setBrush(QBrush(color))
+            # Draw threat dot vertically centered, left of the right edge
+            x = self.width() - self.DOT_SIZE - 8
+            y = (self.height() - self.DOT_SIZE) // 2
+            painter.drawEllipse(x, y, self.DOT_SIZE, self.DOT_SIZE)
+        finally:
+            painter.end()
+
+
+class StatusDock(QWidget):
+    """
+    Horizontal strip of CharacterChip widgets.
+
+    Mounts above the preview grid in MainTab. Designed to mirror the set
+    of active preview windows: one chip per window_id. Chips emit
+    chip_clicked when activated; the dock re-emits to the parent.
+    """
+
+    chip_clicked = Signal(str)  # window_id
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.logger = logging.getLogger(__name__)
+        self._chips: dict[str, CharacterChip] = {}
+
+        self.setFixedHeight(56)
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(4, 2, 4, 2)
+        outer.setSpacing(0)
+
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self._scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._scroll.setFrameShape(QFrame.Shape.NoFrame)
+        outer.addWidget(self._scroll)
+
+        self._strip = QWidget()
+        self._strip_layout = QHBoxLayout(self._strip)
+        self._strip_layout.setContentsMargins(4, 2, 4, 2)
+        self._strip_layout.setSpacing(6)
+        self._strip_layout.addStretch()  # push chips left, fill empty space right
+        self._scroll.setWidget(self._strip)
+
+        self.setStyleSheet(
+            """
+            StatusDock {
+                background-color: #1f1f1f;
+                border-bottom: 1px solid #3a3a3a;
+            }
+            """
+        )
+
+    # ----- public API -------------------------------------------------------
+    def chip_count(self) -> int:
+        return len(self._chips)
+
+    def has_chip(self, window_id: str) -> bool:
+        return window_id in self._chips
+
+    def add_chip(self, window_id: str, character_name: str) -> CharacterChip | None:
+        if window_id in self._chips:
+            return None
+        chip = CharacterChip(window_id, character_name, parent=self._strip)
+        chip.clicked.connect(self.chip_clicked.emit)
+        # Insert before the trailing stretch (last item)
+        insert_at = max(0, self._strip_layout.count() - 1)
+        self._strip_layout.insertWidget(insert_at, chip)
+        self._chips[window_id] = chip
+        return chip
+
+    def remove_chip(self, window_id: str) -> bool:
+        chip = self._chips.pop(window_id, None)
+        if chip is None:
+            return False
+        self._strip_layout.removeWidget(chip)
+        chip.deleteLater()
+        return True
+
+    def clear(self) -> None:
+        for window_id in list(self._chips.keys()):
+            self.remove_chip(window_id)
+
+    def set_threat_state(self, level: ThreatLevel | None, system: str | None = None) -> int:
+        """Fan out a single threat state to every chip. Returns count updated."""
+        count = 0
+        for chip in list(self._chips.values()):
+            try:
+                chip.set_threat_state(level, system)
+                count += 1
+            except RuntimeError:
+                continue
+        return count
+
+    def set_chip_system(self, window_id: str, system: str | None) -> bool:
+        chip = self._chips.get(window_id)
+        if chip is None:
+            return False
+        chip.set_system(system)
+        return True
+
+    def sync_from_window_ids(self, desired: dict[str, str]) -> tuple[list[str], list[str]]:
+        """
+        Bulk diff: ensure chips match `desired` mapping of window_id -> name.
+
+        Returns (added_ids, removed_ids).
+        """
+        existing = set(self._chips.keys())
+        target = set(desired.keys())
+        added = []
+        removed = []
+        for window_id in existing - target:
+            if self.remove_chip(window_id):
+                removed.append(window_id)
+        for window_id in target - existing:
+            name = desired[window_id]
+            if self.add_chip(window_id, name) is not None:
+                added.append(window_id)
+        return added, removed

--- a/tests/test_main_tab.py
+++ b/tests/test_main_tab.py
@@ -8446,6 +8446,7 @@ class TestMainTabSetupUi:
             mock_container = MagicMock()
             mock_flow_layout = MagicMock()
 
+            mock_status_dock = MagicMock()
             with patch("argus_overview.ui.main_tab.QVBoxLayout") as mock_vbox:
                 with patch("argus_overview.ui.main_tab.QScrollArea", return_value=mock_scroll):
                     with patch("argus_overview.ui.main_tab.QWidget", return_value=mock_container):
@@ -8453,29 +8454,33 @@ class TestMainTabSetupUi:
                             "argus_overview.ui.main_tab.FlowLayout",
                             return_value=mock_flow_layout,
                         ):
-                            mock_layout = MagicMock()
-                            mock_vbox.return_value = mock_layout
+                            with patch(
+                                "argus_overview.ui.status_dock.StatusDock",
+                                return_value=mock_status_dock,
+                            ):
+                                mock_layout = MagicMock()
+                                mock_vbox.return_value = mock_layout
 
-                            tab._setup_ui()
+                                tab._setup_ui()
 
-                            # Layout created and set
-                            tab.setLayout.assert_called_once_with(mock_layout)
+                                # Layout created and set
+                                tab.setLayout.assert_called_once_with(mock_layout)
 
-                            # Toolbar, layout controls, status bar created
-                            tab._create_toolbar.assert_called_once()
-                            tab._create_layout_controls.assert_called_once()
-                            tab._create_status_bar.assert_called_once()
+                                # Toolbar, layout controls, status bar created
+                                tab._create_toolbar.assert_called_once()
+                                tab._create_layout_controls.assert_called_once()
+                                tab._create_status_bar.assert_called_once()
 
-                            # Scroll area configured
-                            mock_scroll.setWidgetResizable.assert_called_once_with(True)
-                            mock_scroll.setWidget.assert_called_once_with(mock_container)
+                                # Scroll area configured
+                                mock_scroll.setWidgetResizable.assert_called_once_with(True)
+                                mock_scroll.setWidget.assert_called_once_with(mock_container)
 
-                            # Preview container and layout stored
-                            assert tab.preview_container is mock_container
-                            assert tab.preview_layout is mock_flow_layout
+                                # Preview container and layout stored
+                                assert tab.preview_container is mock_container
+                                assert tab.preview_layout is mock_flow_layout
 
-                            # All widgets added to layout
-                            assert mock_layout.addWidget.call_count == 4
+                                # 5 widgets added to layout (PR2 added status dock)
+                                assert mock_layout.addWidget.call_count == 5
 
 
 # =============================================================================

--- a/tests/test_status_dock.py
+++ b/tests/test_status_dock.py
@@ -1,0 +1,407 @@
+"""Tests for the character status dock (PR2)."""
+
+from unittest.mock import MagicMock
+
+from argus_overview.intel.parser import ThreatLevel
+from argus_overview.ui.status_dock import (
+    CharacterChip,
+    StatusDock,
+    _initials,
+    accent_for,
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+class TestInitials:
+    def test_single_word(self):
+        assert _initials("Solo") == "SO"
+
+    def test_two_words(self):
+        assert _initials("Foo Bar") == "FB"
+
+    def test_underscores(self):
+        assert _initials("foo_bar") == "FB"
+
+    def test_empty(self):
+        assert _initials("") == "?"
+
+    def test_three_words_uses_first_and_last(self):
+        assert _initials("Alice Beta Gamma") == "AG"
+
+
+class TestAccentFor:
+    def test_deterministic(self):
+        assert accent_for("Pilot1").rgb() == accent_for("Pilot1").rgb()
+
+    def test_different_names_likely_differ(self):
+        # Not guaranteed but extremely probable across the small palette
+        names = ["A", "B", "C", "D", "E", "F", "G", "H"]
+        seen = {accent_for(n).rgb() for n in names}
+        # At least 3 different accents in 8 names is a generous lower bound
+        assert len(seen) >= 3
+
+
+# =============================================================================
+# CharacterChip
+# =============================================================================
+
+
+class TestCharacterChip:
+    def test_init_sets_basic_state(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            assert chip.window_id == "0xABC"
+            assert chip.character_name == "TestPilot"
+            assert chip._system is None
+            assert chip._threat_level is None
+        finally:
+            chip.deleteLater()
+
+    def test_set_system_updates_label(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_system("HED-GP")
+            assert chip._system == "HED-GP"
+            assert chip._system_label.text() == "HED-GP"
+        finally:
+            chip.deleteLater()
+
+    def test_set_system_none_uses_dash(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_system("HED-GP")
+            chip.set_system(None)
+            assert chip._system_label.text() == "—"
+        finally:
+            chip.deleteLater()
+
+    def test_set_threat_state_stores_level(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_threat_state(ThreatLevel.WARNING, "HED-GP")
+            assert chip._threat_level == ThreatLevel.WARNING
+            assert chip._threat_alpha == 1.0
+            assert chip._system == "HED-GP"
+        finally:
+            chip.deleteLater()
+
+    def test_set_threat_state_clear_resets(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_threat_state(ThreatLevel.DANGER, "Jita")
+            chip.set_threat_state(ThreatLevel.CLEAR)
+            assert chip._threat_level is None
+            assert chip._threat_alpha == 0.0
+        finally:
+            chip.deleteLater()
+
+    def test_set_threat_state_none_resets(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_threat_state(ThreatLevel.DANGER, "Jita")
+            chip.set_threat_state(None)
+            assert chip._threat_level is None
+        finally:
+            chip.deleteLater()
+
+    def test_set_threat_state_alpha_clamped(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_threat_state(ThreatLevel.WARNING, "HED-GP", alpha=2.5)
+            assert chip._threat_alpha == 1.0
+            chip.set_threat_state(ThreatLevel.WARNING, "HED-GP", alpha=-0.5)
+            assert chip._threat_alpha == 0.0
+        finally:
+            chip.deleteLater()
+
+    def test_click_emits_window_id(self, qapp):
+        from PySide6.QtCore import QPoint, Qt
+        from PySide6.QtGui import QMouseEvent
+
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            received: list[str] = []
+            chip.clicked.connect(received.append)
+            event = QMouseEvent(
+                QMouseEvent.Type.MouseButtonPress,
+                QPoint(5, 5),
+                Qt.MouseButton.LeftButton,
+                Qt.MouseButton.LeftButton,
+                Qt.KeyboardModifier.NoModifier,
+            )
+            chip.mousePressEvent(event)
+            assert received == ["0xABC"]
+        finally:
+            chip.deleteLater()
+
+    def test_right_click_does_not_emit(self, qapp):
+        from PySide6.QtCore import QPoint, Qt
+        from PySide6.QtGui import QMouseEvent
+
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            received: list[str] = []
+            chip.clicked.connect(received.append)
+            event = QMouseEvent(
+                QMouseEvent.Type.MouseButtonPress,
+                QPoint(5, 5),
+                Qt.MouseButton.RightButton,
+                Qt.MouseButton.RightButton,
+                Qt.KeyboardModifier.NoModifier,
+            )
+            chip.mousePressEvent(event)
+            assert received == []
+        finally:
+            chip.deleteLater()
+
+    def test_paint_event_no_threat_does_not_crash(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.resize(200, 40)
+            chip.repaint()
+        finally:
+            chip.deleteLater()
+
+    def test_paint_event_with_threat_does_not_crash(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.resize(200, 40)
+            chip.set_threat_state(ThreatLevel.CRITICAL, "Jita")
+            chip.repaint()
+        finally:
+            chip.deleteLater()
+
+    def test_tooltip_includes_system_and_threat(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_system("HED-GP")
+            chip.set_threat_state(ThreatLevel.WARNING, "HED-GP")
+            tip = chip.toolTip()
+            assert "TestPilot" in tip
+            assert "HED-GP" in tip
+            assert "warning" in tip
+        finally:
+            chip.deleteLater()
+
+
+# =============================================================================
+# StatusDock
+# =============================================================================
+
+
+class TestStatusDock:
+    def test_init_empty(self, qapp):
+        dock = StatusDock()
+        try:
+            assert dock.chip_count() == 0
+        finally:
+            dock.deleteLater()
+
+    def test_add_chip(self, qapp):
+        dock = StatusDock()
+        try:
+            chip = dock.add_chip("0x1", "Alice")
+            assert chip is not None
+            assert dock.chip_count() == 1
+            assert dock.has_chip("0x1")
+        finally:
+            dock.deleteLater()
+
+    def test_add_chip_duplicate_returns_none(self, qapp):
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dup = dock.add_chip("0x1", "Alice")
+            assert dup is None
+            assert dock.chip_count() == 1
+        finally:
+            dock.deleteLater()
+
+    def test_remove_chip(self, qapp):
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            assert dock.remove_chip("0x1") is True
+            assert dock.chip_count() == 1
+            assert not dock.has_chip("0x1")
+            assert dock.has_chip("0x2")
+        finally:
+            dock.deleteLater()
+
+    def test_remove_chip_missing_returns_false(self, qapp):
+        dock = StatusDock()
+        try:
+            assert dock.remove_chip("nope") is False
+        finally:
+            dock.deleteLater()
+
+    def test_clear_removes_all(self, qapp):
+        dock = StatusDock()
+        try:
+            for i in range(5):
+                dock.add_chip(f"0x{i}", f"Pilot{i}")
+            dock.clear()
+            assert dock.chip_count() == 0
+        finally:
+            dock.deleteLater()
+
+    def test_set_threat_state_fans_to_all_chips(self, qapp):
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            count = dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+            assert count == 2
+            for chip in dock._chips.values():
+                assert chip._threat_level == ThreatLevel.DANGER
+                assert chip._system == "HED-GP"
+        finally:
+            dock.deleteLater()
+
+    def test_set_threat_state_clear(self, qapp):
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.set_threat_state(ThreatLevel.DANGER, "Jita")
+            dock.set_threat_state(ThreatLevel.CLEAR)
+            for chip in dock._chips.values():
+                assert chip._threat_level is None
+        finally:
+            dock.deleteLater()
+
+    def test_set_chip_system_updates_one_chip(self, qapp):
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            assert dock.set_chip_system("0x1", "HED-GP") is True
+            assert dock._chips["0x1"]._system == "HED-GP"
+            assert dock._chips["0x2"]._system is None
+        finally:
+            dock.deleteLater()
+
+    def test_set_chip_system_unknown_returns_false(self, qapp):
+        dock = StatusDock()
+        try:
+            assert dock.set_chip_system("nope", "Jita") is False
+        finally:
+            dock.deleteLater()
+
+    def test_chip_clicked_signal_propagates(self, qapp):
+        dock = StatusDock()
+        try:
+            received: list[str] = []
+            dock.chip_clicked.connect(received.append)
+            chip = dock.add_chip("0xABC", "Alice")
+            chip.clicked.emit("0xABC")
+            assert received == ["0xABC"]
+        finally:
+            dock.deleteLater()
+
+    def test_sync_from_window_ids_adds_and_removes(self, qapp):
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            added, removed = dock.sync_from_window_ids({"0x2": "Bob", "0x3": "Carol"})
+            assert added == ["0x3"]
+            assert removed == ["0x1"]
+            assert dock.has_chip("0x2") and dock.has_chip("0x3")
+            assert not dock.has_chip("0x1")
+        finally:
+            dock.deleteLater()
+
+    def test_sync_from_window_ids_empty_clears(self, qapp):
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            added, removed = dock.sync_from_window_ids({})
+            assert added == []
+            assert removed == ["0x1"]
+            assert dock.chip_count() == 0
+        finally:
+            dock.deleteLater()
+
+
+# =============================================================================
+# MainWindowV21 wiring — dock receives threat fan-out
+# =============================================================================
+
+
+class TestMainWindowV21StatusDockFanout:
+    def test_visual_border_alert_calls_dock_set_threat_state(self):
+        from argus_overview.intel.alerts import AlertType
+        from argus_overview.intel.parser import IntelReport, ThreatLevel
+        from argus_overview.ui.main_window_v21 import MainWindowV21
+
+        window = MainWindowV21.__new__(MainWindowV21)
+        window.main_tab = MagicMock()
+        window.main_tab.window_manager = MagicMock()
+        window.main_tab.status_dock = MagicMock()
+        window.system_tray = MagicMock()
+
+        report = IntelReport(
+            system="HED-GP",
+            threat_level=ThreatLevel.DANGER,
+            hostile_count=2,
+            ship_types=[],
+            player_names=[],
+            raw_message="hostiles HED-GP",
+        )
+
+        window._on_intel_alert(report, AlertType.VISUAL_BORDER)
+
+        window.main_tab.status_dock.set_threat_state.assert_called_once_with(
+            ThreatLevel.DANGER, "HED-GP"
+        )
+
+    def test_audio_alert_does_not_touch_dock(self):
+        from argus_overview.intel.alerts import AlertType
+        from argus_overview.intel.parser import IntelReport, ThreatLevel
+        from argus_overview.ui.main_window_v21 import MainWindowV21
+
+        window = MainWindowV21.__new__(MainWindowV21)
+        window.main_tab = MagicMock()
+        window.main_tab.window_manager = MagicMock()
+        window.main_tab.status_dock = MagicMock()
+        window.system_tray = MagicMock()
+
+        report = IntelReport(
+            system="HED-GP",
+            threat_level=ThreatLevel.WARNING,
+            hostile_count=1,
+            ship_types=[],
+            player_names=[],
+            raw_message="neut",
+        )
+
+        window._on_intel_alert(report, AlertType.AUDIO)
+
+        window.main_tab.status_dock.set_threat_state.assert_not_called()
+
+    def test_dock_optional_does_not_crash_when_missing(self):
+        from argus_overview.intel.alerts import AlertType
+        from argus_overview.intel.parser import IntelReport, ThreatLevel
+        from argus_overview.ui.main_window_v21 import MainWindowV21
+
+        window = MainWindowV21.__new__(MainWindowV21)
+        window.main_tab = MagicMock(spec=["window_manager"])
+        window.main_tab.window_manager = MagicMock()
+        window.system_tray = MagicMock()
+
+        report = IntelReport(
+            system="HED-GP",
+            threat_level=ThreatLevel.DANGER,
+            hostile_count=2,
+            ship_types=[],
+            player_names=[],
+            raw_message="hostiles",
+        )
+
+        # Should not raise even though main_tab has no status_dock attr
+        window._on_intel_alert(report, AlertType.VISUAL_BORDER)
+        window.main_tab.window_manager.apply_threat_state.assert_called_once()


### PR DESCRIPTION
> **Stacked on #62** — base is \`feat/intel-aware-preview-borders\`. Merge that first; this PR will retarget to \`main\` automatically.

## Summary
- New \`StatusDock\` widget — horizontal strip of \`CharacterChip\` widgets above the preview grid
- Each chip: 28px colored-initials avatar (deterministic accent per character), name, system label, threat-tint dot
- Click a chip to activate the matching window — reuses \`_on_window_activated\` so Qt focus path is unchanged
- Threat dots track the same intel signal that tints preview borders (PR #62) so border + chip stay in lock-step
- Visibility gated on \`thumbnails.show_status_dock\` (default true)

## Why this matters
EVE-O Preview cannot show per-character system or threat state — it has no access to the chat-log intel parser running in this process. The dock makes that data first-class, glanceable, and clickable. It's also the foundation for the next round of differentiators (focus mode, system-cluster grouping, etc.).

## Architecture notes
- \`StatusDock\` owns chip lifecycle (\`add_chip\`/\`remove_chip\`/\`clear\`/\`sync_from_window_ids\`)
- \`MainTab._sync_status_dock\` mirrors \`window_manager.preview_frames\` on every add/remove site
- \`MainWindowV21._on_intel_alert\` pushes \`VISUAL_BORDER\` alerts to the dock alongside the preview-frame fan-out from #62
- Per-character system tracking still uses the shared parser \`current_system\` — chip API already takes a \`system\` arg so per-char tracking can land later without API changes

## Test plan
- [x] 35 new tests in \`tests/test_status_dock.py\` (chip init/clicks/threat state/paint smoke; dock add/remove/clear/sync/fan-out; main_window wiring + optional-dock fallback)
- [x] 1 updated existing test (\`test_setup_ui_creates_layout_and_widgets\`) for +1 addWidget call
- [x] Full suite: 2239 passed, 5 skipped, 0 failures
- [x] \`ruff check\` + \`ruff format --check\` clean

## Follow-ups
- Per-character \`current_system\` tracking (each EVE char has its own log file)
- Focus mode (clicked thumb scales up, others desaturate)
- System-cluster grouping in the dock (visually group chips by shared system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)