### PR TITLE
feat(ui): preview focus mode (spotlight + dim)

### DIFF
--- a/src/argus_overview/ui/main_tab.py
+++ b/src/argus_overview/ui/main_tab.py
@@ -589,6 +589,7 @@ class WindowPreviewWidget(QWidget):
     window_activated = Signal(str)  # window_id
     window_removed = Signal(str)  # window_id
     label_changed = Signal(str, str)  # window_id, new_label
+    focus_requested = Signal(str)  # window_id — PR3 spotlight toggle
 
     def __init__(
         self,
@@ -686,10 +687,18 @@ class WindowPreviewWidget(QWidget):
         if self._show_session_timer:
             self.session_timer.start(60000)  # Update every minute
 
-        # Opacity effect for hover
+        # Opacity effect for hover (and PR3 spotlight dim state)
         self.opacity_effect = QGraphicsOpacityEffect(self)
         self.opacity_effect.setOpacity(1.0)
         self.setGraphicsEffect(self.opacity_effect)
+
+        # PR3 — focus/spotlight mode state.
+        # mode is one of: None (normal), "focused" (this widget is the
+        # spotlight target), "dimmed" (another widget has spotlight).
+        self._spotlight_mode: str | None = None
+        # Cached size constraints so we can restore them when leaving focus.
+        self._normal_min_size: QSize = self.minimumSize()
+        self._normal_max_size: QSize = self.maximumSize()
 
     def _load_settings(self):
         """Load settings from settings_manager"""
@@ -902,6 +911,36 @@ class WindowPreviewWidget(QWidget):
             self._pulse_timer.stop()
         self.update()
 
+    def set_spotlight(self, mode: str | None) -> None:
+        """
+        Apply or clear focus/spotlight presentation.
+
+        Args:
+            mode: 'focused' to upscale + full opacity (this widget is the
+                spotlight target), 'dimmed' to fade and desaturate (another
+                widget owns the spotlight), None to return to normal.
+        """
+        if mode not in (None, "focused", "dimmed"):
+            raise ValueError(f"Invalid spotlight mode: {mode!r}")
+        self._spotlight_mode = mode
+
+        if mode == "focused":
+            # Allow growth beyond the normal max so the focused widget
+            # actually uses the freed space when others are minimized/hidden.
+            self.setMinimumSize(QSize(360, 270))
+            self.setMaximumSize(QSize(16777215, 16777215))  # QWIDGETSIZE_MAX
+            self.opacity_effect.setOpacity(1.0)
+        elif mode == "dimmed":
+            self.setMinimumSize(self._normal_min_size)
+            self.setMaximumSize(self._normal_max_size)
+            self.opacity_effect.setOpacity(0.25)
+        else:  # None — restore baseline
+            self.setMinimumSize(self._normal_min_size)
+            self.setMaximumSize(self._normal_max_size)
+            # Hover state may want partial opacity; reset to full on exit.
+            self.opacity_effect.setOpacity(self._opacity_on_hover if self._is_hovered else 1.0)
+        self.update()
+
     def flash_border(self, color: str, duration_ms: int) -> None:
         """
         Legacy color/duration border flash hook used by border_flash_requested.
@@ -1017,6 +1056,18 @@ class WindowPreviewWidget(QWidget):
                 self.window_activated.emit(self.window_id)
                 self.logger.info(f"Activating window: {self.window_id}")
             self._drag_start_pos = None
+
+    def mouseDoubleClickEvent(self, event):
+        """PR3: double-click toggles spotlight focus mode for this window."""
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.focus_requested.emit(self.window_id)
+            event.accept()
+            # Cancel the pending single-click activation that the
+            # preceding press recorded; otherwise the window still
+            # activates beneath the focus toggle.
+            self._drag_start_pos = None
+            return
+        super().mouseDoubleClickEvent(event)
 
     def contextMenuEvent(self, event):
         """Handle right-click context menu (v2.3 - uses ActionRegistry)"""
@@ -1291,6 +1342,9 @@ class MainTab(QWidget):
         self.capture_system = capture_system
         self.character_manager = character_manager
         self.settings_manager = settings_manager
+
+        # PR3: focus mode state — None = normal, str = window_id holding spotlight
+        self._focus_window_id: str | None = None
 
         # v2.2 State
         self._thumbnails_visible = True
@@ -1756,6 +1810,9 @@ class MainTab(QWidget):
                 frame.window_removed.connect(
                     self._on_window_removed, Qt.ConnectionType.UniqueConnection
                 )
+                frame.focus_requested.connect(
+                    self._on_focus_requested, Qt.ConnectionType.UniqueConnection
+                )
 
                 # Add to layout
                 self.preview_layout.addWidget(frame)
@@ -1871,6 +1928,9 @@ class MainTab(QWidget):
             frame.window_removed.connect(
                 self._on_window_removed, Qt.ConnectionType.UniqueConnection
             )
+            frame.focus_requested.connect(
+                self._on_focus_requested, Qt.ConnectionType.UniqueConnection
+            )
             self.preview_layout.addWidget(frame)
             self._sync_status_dock()
             return True
@@ -1930,6 +1990,46 @@ class MainTab(QWidget):
                 self.logger.info(f"Added {added} windows to preview")
                 self._update_status()
 
+    # ----- PR3 focus mode controller --------------------------------------
+    def _on_focus_requested(self, window_id: str) -> None:
+        """Toggle spotlight focus for the given window."""
+        if self._focus_window_id == window_id:
+            self.exit_focus_mode()
+        else:
+            self.enter_focus_mode(window_id)
+
+    def enter_focus_mode(self, window_id: str) -> None:
+        """Spotlight one window: scale up, dim others. Idempotent."""
+        if window_id not in self.window_manager.preview_frames:
+            self.logger.debug(f"Cannot enter focus mode — unknown window {window_id}")
+            return
+        self._focus_window_id = window_id
+        self._apply_focus_state()
+
+    def exit_focus_mode(self) -> None:
+        """Restore normal grid presentation."""
+        if self._focus_window_id is None:
+            return
+        self._focus_window_id = None
+        self._apply_focus_state()
+
+    def is_focus_mode_active(self) -> bool:
+        return self._focus_window_id is not None
+
+    def _apply_focus_state(self) -> None:
+        """Push current focus mode to all preview frames."""
+        focus_id = self._focus_window_id
+        for wid, frame in list(self.window_manager.preview_frames.items()):
+            try:
+                if focus_id is None:
+                    frame.set_spotlight(None)
+                elif wid == focus_id:
+                    frame.set_spotlight("focused")
+                else:
+                    frame.set_spotlight("dimmed")
+            except RuntimeError:
+                continue
+
     def _on_window_activated(self, window_id: str):
         """Handle window activation with optional auto-minimize of previous window"""
         from argus_overview.utils.window_utils import run_x11_subprocess
@@ -1977,11 +2077,23 @@ class MainTab(QWidget):
                 frame.window_removed.disconnect(self._on_window_removed)
             except (RuntimeError, TypeError):
                 pass
+            try:
+                frame.focus_requested.disconnect(self._on_focus_requested)
+            except (RuntimeError, TypeError):
+                pass
             # Stop per-frame timers
             frame.session_timer.stop()
+        # If we just removed the spotlight target, drop focus state.
+        # getattr keeps this safe when called via test helpers that bypass __init__.
+        if getattr(self, "_focus_window_id", None) == window_id:
+            self._focus_window_id = None
         self.window_manager.remove_window(window_id)
         self._update_status()
-        self._sync_status_dock()
+        if hasattr(self, "status_dock"):
+            self._sync_status_dock()
+        if hasattr(self, "_focus_window_id"):
+            # Re-apply (covers both: focus cleared, or other tile removed mid-focus)
+            self._apply_focus_state()
 
     def _remove_all_windows(self):
         """Remove all windows from preview"""
@@ -2140,6 +2252,12 @@ class MainTab(QWidget):
     def keyPressEvent(self, event: QKeyEvent):
         """Handle keyboard shortcuts for window navigation"""
         key = event.key()
+
+        # PR3: Escape exits focus mode (only consume the key if active)
+        if key == Qt.Key.Key_Escape and self.is_focus_mode_active():
+            self.exit_focus_mode()
+            event.accept()
+            return
 
         # Number keys 1-9 to activate window by index
         if Qt.Key.Key_1 <= key <= Qt.Key.Key_9:

--- a/tests/test_main_tab.py
+++ b/tests/test_main_tab.py
@@ -9409,3 +9409,260 @@ class TestMainWindowV21IntelAlertThreatFanout:
         window._on_intel_alert("not a report", AlertType.VISUAL_BORDER)
 
         window.main_tab.window_manager.apply_threat_state.assert_not_called()
+
+
+# =============================================================================
+# Spotlight / Focus Mode Tests (PR3)
+# =============================================================================
+
+
+class TestWindowPreviewWidgetSpotlight:
+    """Tests for set_spotlight() state transitions."""
+
+    def _make(self, qapp):
+        from argus_overview.ui.main_tab import WindowPreviewWidget
+
+        widget = WindowPreviewWidget(
+            window_id="0xABC",
+            character_name="TestPilot",
+            capture_system=MagicMock(),
+        )
+        return widget
+
+    def test_set_spotlight_focused_grows(self, qapp):
+        widget = self._make(qapp)
+        try:
+            widget.set_spotlight("focused")
+            assert widget._spotlight_mode == "focused"
+            # Focused widget gets a larger min size than the default 200x150
+            assert widget.minimumWidth() >= 360
+            assert widget.opacity_effect.opacity() == 1.0
+        finally:
+            widget.deleteLater()
+
+    def test_set_spotlight_dimmed_drops_opacity(self, qapp):
+        widget = self._make(qapp)
+        try:
+            widget.set_spotlight("dimmed")
+            assert widget._spotlight_mode == "dimmed"
+            assert widget.opacity_effect.opacity() == 0.25
+        finally:
+            widget.deleteLater()
+
+    def test_set_spotlight_none_restores(self, qapp):
+        widget = self._make(qapp)
+        try:
+            normal_min = widget._normal_min_size
+            widget.set_spotlight("focused")
+            widget.set_spotlight(None)
+            assert widget._spotlight_mode is None
+            assert widget.minimumSize() == normal_min
+            assert widget.opacity_effect.opacity() == 1.0
+        finally:
+            widget.deleteLater()
+
+    def test_set_spotlight_invalid_raises(self, qapp):
+        import pytest
+
+        widget = self._make(qapp)
+        try:
+            with pytest.raises(ValueError):
+                widget.set_spotlight("bogus")
+        finally:
+            widget.deleteLater()
+
+    def test_double_click_emits_focus_requested(self, qapp):
+        from PySide6.QtCore import QPoint, Qt
+        from PySide6.QtGui import QMouseEvent
+
+        widget = self._make(qapp)
+        try:
+            received: list[str] = []
+            widget.focus_requested.connect(received.append)
+            event = QMouseEvent(
+                QMouseEvent.Type.MouseButtonDblClick,
+                QPoint(50, 50),
+                Qt.MouseButton.LeftButton,
+                Qt.MouseButton.LeftButton,
+                Qt.KeyboardModifier.NoModifier,
+            )
+            widget.mouseDoubleClickEvent(event)
+            assert received == ["0xABC"]
+        finally:
+            widget.deleteLater()
+
+
+class TestMainTabFocusMode:
+    """Tests for MainTab focus mode controller."""
+
+    def _make_tab(self):
+        from argus_overview.ui.main_tab import MainTab
+
+        tab = MainTab.__new__(MainTab)
+        tab.logger = MagicMock()
+        tab._focus_window_id = None
+        tab.window_manager = MagicMock()
+        tab.window_manager.preview_frames = {}
+        return tab
+
+    def test_enter_focus_mode_unknown_window_noop(self):
+        tab = self._make_tab()
+        tab.enter_focus_mode("missing")
+        assert tab._focus_window_id is None
+
+    def test_enter_focus_mode_sets_state_and_fans_out(self):
+        tab = self._make_tab()
+        f1, f2 = MagicMock(), MagicMock()
+        tab.window_manager.preview_frames = {"w1": f1, "w2": f2}
+
+        tab.enter_focus_mode("w1")
+
+        assert tab._focus_window_id == "w1"
+        f1.set_spotlight.assert_called_once_with("focused")
+        f2.set_spotlight.assert_called_once_with("dimmed")
+
+    def test_exit_focus_mode_clears_all(self):
+        tab = self._make_tab()
+        f1, f2 = MagicMock(), MagicMock()
+        tab.window_manager.preview_frames = {"w1": f1, "w2": f2}
+        tab._focus_window_id = "w1"
+
+        tab.exit_focus_mode()
+
+        assert tab._focus_window_id is None
+        f1.set_spotlight.assert_called_once_with(None)
+        f2.set_spotlight.assert_called_once_with(None)
+
+    def test_exit_focus_mode_when_inactive_noop(self):
+        tab = self._make_tab()
+        f1 = MagicMock()
+        tab.window_manager.preview_frames = {"w1": f1}
+
+        tab.exit_focus_mode()
+
+        f1.set_spotlight.assert_not_called()
+
+    def test_on_focus_requested_toggles_on(self):
+        tab = self._make_tab()
+        f1 = MagicMock()
+        tab.window_manager.preview_frames = {"w1": f1}
+
+        tab._on_focus_requested("w1")
+
+        assert tab._focus_window_id == "w1"
+
+    def test_on_focus_requested_toggles_off_when_same_window(self):
+        tab = self._make_tab()
+        f1 = MagicMock()
+        tab.window_manager.preview_frames = {"w1": f1}
+        tab._focus_window_id = "w1"
+
+        tab._on_focus_requested("w1")
+
+        assert tab._focus_window_id is None
+
+    def test_on_focus_requested_swaps_to_different_window(self):
+        tab = self._make_tab()
+        f1, f2 = MagicMock(), MagicMock()
+        tab.window_manager.preview_frames = {"w1": f1, "w2": f2}
+        tab._focus_window_id = "w1"
+
+        tab._on_focus_requested("w2")
+
+        assert tab._focus_window_id == "w2"
+        # f1 should be dimmed now (used to be focused), f2 focused
+        f1.set_spotlight.assert_called_with("dimmed")
+        f2.set_spotlight.assert_called_with("focused")
+
+    def test_apply_focus_state_skips_deleted_widgets(self):
+        tab = self._make_tab()
+        ok = MagicMock()
+        dead = MagicMock()
+        dead.set_spotlight.side_effect = RuntimeError("widget deleted")
+        tab.window_manager.preview_frames = {"alive": ok, "dead": dead}
+        tab._focus_window_id = "alive"
+
+        tab._apply_focus_state()
+
+        ok.set_spotlight.assert_called_with("focused")
+
+    def test_is_focus_mode_active(self):
+        tab = self._make_tab()
+        assert tab.is_focus_mode_active() is False
+        tab._focus_window_id = "w1"
+        assert tab.is_focus_mode_active() is True
+
+    def test_remove_focused_window_clears_focus(self):
+        from argus_overview.ui.main_tab import MainTab
+
+        tab = MainTab.__new__(MainTab)
+        tab.logger = MagicMock()
+        tab._focus_window_id = "w1"
+        tab.status_dock = MagicMock()
+        tab._update_status = MagicMock()
+
+        # Build a frame mock with the disconnect surface and session_timer
+        frame = MagicMock()
+        wm = MagicMock()
+        wm.preview_frames = {"w1": frame}
+        tab.window_manager = wm
+
+        tab._on_window_removed("w1")
+
+        assert tab._focus_window_id is None
+        wm.remove_window.assert_called_once_with("w1")
+        # Disconnect calls happened
+        frame.window_activated.disconnect.assert_called()
+        frame.focus_requested.disconnect.assert_called()
+
+
+class TestMainTabFocusEscapeKey:
+    """Tests that Escape exits focus mode without swallowing other keys."""
+
+    def test_escape_when_focused_exits(self):
+        from PySide6.QtCore import Qt
+        from PySide6.QtGui import QKeyEvent
+
+        from argus_overview.ui.main_tab import MainTab
+
+        tab = MainTab.__new__(MainTab)
+        tab.logger = MagicMock()
+        tab._focus_window_id = "w1"
+        tab.window_manager = MagicMock()
+        tab.window_manager.preview_frames = {"w1": MagicMock()}
+
+        event = QKeyEvent(
+            QKeyEvent.Type.KeyPress,
+            Qt.Key.Key_Escape,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        tab.keyPressEvent(event)
+
+        assert tab._focus_window_id is None
+
+    def test_escape_when_not_focused_passes_through(self):
+        from PySide6.QtCore import Qt
+        from PySide6.QtGui import QKeyEvent
+
+        from argus_overview.ui.main_tab import MainTab
+
+        tab = MainTab.__new__(MainTab)
+        tab.logger = MagicMock()
+        tab._focus_window_id = None
+        tab.window_manager = MagicMock()
+        tab.window_manager.preview_frames = {}
+
+        event = QKeyEvent(
+            QKeyEvent.Type.KeyPress,
+            Qt.Key.Key_Escape,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        # Should not raise even though super().keyPressEvent reaches QWidget
+        # bypassed init — bypass keyPressEvent dispatch by mocking out super
+        # via a real QWidget call would crash, so we just assert the focus
+        # path didn't fire.
+        try:
+            tab.keyPressEvent(event)
+        except RuntimeError:
+            pass  # Expected: super().keyPressEvent hits bypassed-init widget
+        assert tab._focus_window_id is None


### PR DESCRIPTION
> **Stacked on #63 → #62.** Merge order: #62 → #63 → this. Each PR re-targets to \`main\` automatically as its base merges.

## Summary
- Double-click any preview thumbnail to **spotlight** it — that frame grows past the normal 600x450 cap, others fade to 25% opacity
- Double-click again, or press **Escape**, to exit focus mode
- Removing the focused window mid-focus drops focus and restores the rest
- New \`focus_requested\` signal + \`set_spotlight(mode)\` state machine on \`WindowPreviewWidget\`
- \`MainTab\` owns the controller: \`enter_focus_mode\`, \`exit_focus_mode\`, \`_apply_focus_state\` fan-out

## Why this matters
EVE-O Preview has nothing like this — every thumbnail is the same size all the time. Argus now has a one-action way to monitor a single client at a glance while keeping fleet awareness in soft focus. Combined with #62 + #63: a danger pulse on one frame makes the call to spotlight obvious; the chip-strip + dimmed thumbnails keep peripheral awareness intact.

## Architecture notes
- \`set_spotlight(mode)\`: \`None\` / \`'focused'\` / \`'dimmed'\`. Caches \`_normal_min_size\` / \`_normal_max_size\` at init for clean restore. Drives the existing \`opacity_effect\`
- \`mouseDoubleClickEvent\` consumes the second-click activation so the focus toggle isn't paired with an unwanted EVE-window switch
- \`_on_window_removed\` got \`getattr\`/\`hasattr\` guards so the existing bypassed-init test helpers still pass
- Escape only consumes the key when focus mode is active; number-key window switching is unaffected

## Test plan
- [x] 17 new tests (\`TestWindowPreviewWidgetSpotlight\`, \`TestMainTabFocusMode\`, \`TestMainTabFocusEscapeKey\`)
- [x] 4 existing \`_on_window_removed\` tests preserved
- [x] Full suite: **2256 passed, 5 skipped, 0 failures**
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Manual smoke: import 4+ EVE windows, double-click, verify spotlight + dim, Esc exit, double-click another for swap

## Follow-ups
- Toolbar button + tooltip for focus mode (right now the only entry is double-click)
- Per-character \`current_system\` tracking (still the architectural unlock for chip-level threat differentiation)
- Workspace minimap (bird's-eye thumbnail-of-thumbnails) — leverages the already-shrinking dimmed frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)