### PR TITLE
feat(intel): per-character system tracking from Local logs

### DIFF
--- a/src/argus_overview/intel/character_location.py
+++ b/src/argus_overview/intel/character_location.py
@@ -1,0 +1,283 @@
+"""
+Character Location Tracker — per-character current-system tracking from EVE logs.
+
+EVE Online writes a separate Local channel chat log per character session.
+Each Local log file has:
+
+    1. A header block declaring the listener (the character) and channel:
+
+         ---------------------------------------------------------------
+           Channel ID:    Local
+           Channel Name:  Local
+           Listener:      MyCharName
+           Session Started: 2024.01.15 14:30:00
+         ---------------------------------------------------------------
+
+    2. Lines of the form
+         [ 2024.01.15 14:30:05 ] EVE System > Channel changed to Local : Jita
+       whenever the character jumps into a new system.
+
+This tracker polls today's Local_*.txt files, parses the listener header
+once per file, then tails each file for "Channel changed to Local" lines
+and maintains a {character_name -> current_system} map. It emits
+character_system_changed when a character's system updates.
+
+Files are UTF-16-LE (matches ChatLogWatcher).
+
+PR4 of the intel-aware UI uplift. Pairs with the chip strip + preview
+borders so threat fan-out and chip system labels can become per-character.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from PySide6.QtCore import QObject, QTimer, Signal
+
+# Header line: "  Listener:      MyCharName"
+# Whitespace before label, around colon, and before/after name is variable.
+_LISTENER_RE = re.compile(r"^\s*Listener:\s*(?P<name>.+?)\s*$")
+
+# Channel-changed line as it appears inside a Local log:
+#   [ 2024.01.15 14:30:05 ] EVE System > Channel changed to Local : Jita
+_CHANNEL_CHANGED_RE = re.compile(
+    r"\[\s*\d{4}\.\d{2}\.\d{2}\s+\d{2}:\d{2}:\d{2}\s*\]"
+    r"\s*EVE\s+System\s*>\s*Channel changed to Local\s*:\s*(?P<system>.+?)\s*$"
+)
+
+# Local logs are written one-per-character. Filename pattern:
+#   Local_YYYYMMDD_HHMMSS_<charid>.txt   (current EVE clients, charid optional)
+_LOCAL_FILE_GLOB = "Local_*.txt"
+
+# How many bytes from the start of the file to scan for the Listener header.
+# The header is small (~300 bytes incl. UTF-16 BOM); 4KB is generous.
+_HEADER_SCAN_BYTES = 4096
+
+
+def find_eve_chat_log_directory() -> Path | None:
+    """Locate the EVE Online chat log directory.
+
+    Mirrors ChatLogWatcher.find_log_directory but lives here so the tracker
+    can be used without instantiating a watcher.
+    """
+    candidates = [
+        Path.home() / ".eve" / "logs" / "Chatlogs",
+        Path.home()
+        / ".local"
+        / "share"
+        / "Steam"
+        / "steamapps"
+        / "compatdata"
+        / "8500"
+        / "pfx"
+        / "drive_c"
+        / "users"
+        / "steamuser"
+        / "Documents"
+        / "EVE"
+        / "logs"
+        / "Chatlogs",
+        Path.home()
+        / ".steam"
+        / "steam"
+        / "steamapps"
+        / "compatdata"
+        / "8500"
+        / "pfx"
+        / "drive_c"
+        / "users"
+        / "steamuser"
+        / "Documents"
+        / "EVE"
+        / "logs"
+        / "Chatlogs",
+        Path.home() / "Documents" / "EVE" / "logs" / "Chatlogs",
+    ]
+    for path in candidates:
+        if path.exists() and path.is_dir():
+            return path
+    return None
+
+
+@dataclass
+class _FileState:
+    """Tail-cursor state for one Local log file."""
+
+    listener: str | None
+    position: int  # next read offset
+
+
+class CharacterLocationTracker(QObject):
+    """Per-character current-system tracker.
+
+    Polls Local_*.txt files in the EVE chat log directory, parses the
+    Listener header once per file, then tails each file for
+    "Channel changed to Local : <System>" lines.
+
+    Signals:
+        character_system_changed(str, str): (character_name, system)
+            Emitted when a character moves to a new system. Also fires
+            once per character on initial detection.
+    """
+
+    character_system_changed = Signal(str, str)  # char_name, system
+
+    def __init__(
+        self,
+        log_directory: Path | None = None,
+        poll_interval_ms: int = 2000,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.logger = logging.getLogger(__name__)
+        self._explicit_log_dir = log_directory
+        self._log_directory: Path | None = log_directory
+        self.poll_interval_ms = max(250, int(poll_interval_ms))
+
+        # Per-file cursor state, keyed by absolute path.
+        self._file_state: dict[Path, _FileState] = {}
+        # Authoritative location map: character_name -> current_system
+        self._locations: dict[str, str] = {}
+
+        self._poll_timer = QTimer(self)
+        self._poll_timer.timeout.connect(self._poll)
+        self._running = False
+
+    # ---- Public API --------------------------------------------------------
+    def get_system(self, character_name: str) -> str | None:
+        """Return the last known system for character_name, or None."""
+        return self._locations.get(character_name)
+
+    def get_all_locations(self) -> dict[str, str]:
+        """Snapshot of all known {character_name: system} pairs."""
+        return dict(self._locations)
+
+    def start(self) -> None:
+        """Begin polling for Local log changes."""
+        if self._running:
+            return
+        if self._log_directory is None:
+            self._log_directory = find_eve_chat_log_directory()
+        if self._log_directory is None:
+            self.logger.warning(
+                "CharacterLocationTracker: no EVE chat log directory found; tracker will idle."
+            )
+            return
+        self._running = True
+        self._poll_timer.start(self.poll_interval_ms)
+        # Run once immediately so chips populate without a 2s wait
+        self._poll()
+
+    def stop(self) -> None:
+        """Stop polling. Safe to call multiple times."""
+        if not self._running:
+            return
+        self._running = False
+        self._poll_timer.stop()
+
+    def is_running(self) -> bool:
+        return self._running
+
+    # ---- Internals ---------------------------------------------------------
+    def _poll(self) -> None:
+        """Scan today's Local log files and emit any new system changes."""
+        if self._log_directory is None or not self._log_directory.exists():
+            return
+        try:
+            files = list(self._log_directory.glob(_LOCAL_FILE_GLOB))
+        except OSError as e:
+            self.logger.warning(f"Failed to list log directory: {e}")
+            return
+
+        for path in files:
+            try:
+                self._process_file(path)
+            except (OSError, UnicodeDecodeError) as e:
+                self.logger.debug(f"Skipping {path.name}: {e}")
+                continue
+
+    def _process_file(self, path: Path) -> None:
+        """Read header (once) and tail the file for new channel-changed events."""
+        state = self._file_state.get(path)
+        if state is None:
+            listener = self._read_listener(path)
+            # Start at end-of-file so we don't replay history on first open.
+            try:
+                position = path.stat().st_size
+            except OSError:
+                return
+            state = _FileState(listener=listener, position=position)
+            self._file_state[path] = state
+            # Optional: also seed initial system from header-adjacent lines?
+            # Skipped — we wait for the first explicit "Channel changed" line
+            # so we never claim a stale system.
+
+        if state.listener is None:
+            return  # Cannot map systems to a character without a listener.
+
+        try:
+            file_size = path.stat().st_size
+        except OSError:
+            return
+
+        if file_size < state.position:
+            # File rotated/truncated.
+            state.position = 0
+
+        if file_size == state.position:
+            return  # No new content.
+
+        try:
+            with open(path, "rb") as fb:
+                fb.seek(state.position)
+                raw = fb.read()
+                state.position = fb.tell()
+        except OSError as e:
+            self.logger.debug(f"Read failed for {path.name}: {e}")
+            return
+
+        try:
+            text = raw.decode("utf-16-le", errors="ignore")
+        except UnicodeDecodeError:
+            return
+
+        for line in text.splitlines():
+            match = _CHANNEL_CHANGED_RE.search(line)
+            if not match:
+                continue
+            system = match.group("system").strip()
+            self._update_location(state.listener, system)
+
+    def _read_listener(self, path: Path) -> str | None:
+        """Parse the Listener: header from the start of a Local log file."""
+        try:
+            with open(path, "rb") as fb:
+                raw = fb.read(_HEADER_SCAN_BYTES)
+        except OSError:
+            return None
+        if not raw:
+            return None
+        try:
+            text = raw.decode("utf-16-le", errors="ignore")
+        except UnicodeDecodeError:
+            return None
+        for line in text.splitlines():
+            m = _LISTENER_RE.match(line)
+            if m:
+                listener = m.group("name").strip()
+                if listener:
+                    return listener
+        return None
+
+    def _update_location(self, character_name: str, system: str) -> None:
+        prev = self._locations.get(character_name)
+        if prev == system:
+            return
+        self._locations[character_name] = system
+        self.logger.info(
+            f"CharacterLocationTracker: {character_name} -> {system} (was {prev or 'unknown'})"
+        )
+        self.character_system_changed.emit(character_name, system)

--- a/src/argus_overview/ui/main_tab.py
+++ b/src/argus_overview/ui/main_tab.py
@@ -1152,6 +1152,10 @@ class WindowManager:
 
         # State
         self.preview_frames: dict[str, WindowPreviewWidget] = {}
+        # PR4: per-character current system, fed by CharacterLocationTracker.
+        # Survives window add/remove cycles. Used for chip system labels and
+        # (in a follow-up PR) smart per-character threat fan-out.
+        self._character_systems: dict[str, str] = {}
         self.pending_requests: dict[
             str, tuple[str, float]
         ] = {}  # request_id -> (window_id, timestamp)
@@ -1231,6 +1235,23 @@ class WindowManager:
             frame.deleteLater()
 
             self.logger.info(f"Removed window {window_id} from preview")
+
+    def set_character_system(self, character_name: str, system: str | None) -> None:
+        """
+        Record the current system for a character.
+
+        Stored on a per-character map (separate from preview_frames) so the
+        information survives across window add/remove cycles. PR4 uses this
+        only for storage + future smart fan-out; existing fan-out semantics
+        (one shared threat state) are unchanged.
+        """
+        if system is None:
+            self._character_systems.pop(character_name, None)
+        else:
+            self._character_systems[character_name] = system
+
+    def get_character_system(self, character_name: str) -> str | None:
+        return self._character_systems.get(character_name)
 
     def apply_threat_state(self, level: ThreatLevel | None, system: str | None = None) -> int:
         """
@@ -1444,6 +1465,13 @@ class MainTab(QWidget):
             for wid, frame in self.window_manager.preview_frames.items()
         }
         self.status_dock.sync_from_window_ids(desired)
+
+        # PR4: seed chip system labels from cached per-character state so
+        # newly-added chips populate without waiting for the next location
+        # change event.
+        char_systems = getattr(self.window_manager, "_character_systems", {})
+        for char_name, system in char_systems.items():
+            self.status_dock.set_character_system(char_name, system)
 
     def _create_toolbar(self) -> QWidget:
         """Create toolbar using ActionRegistry (v2.3)"""

--- a/src/argus_overview/ui/main_window_v21.py
+++ b/src/argus_overview/ui/main_window_v21.py
@@ -161,7 +161,34 @@ class MainWindowV21(QMainWindow):
             self.auto_discovery.character_gone.connect(self._on_character_gone)
             self.auto_discovery.start()
 
+        # PR4: per-character location tracker (Local channel logs)
+        self._init_location_tracker()
+
         self.logger.info("Main window v2.2 initialized successfully")
+
+    def _init_location_tracker(self) -> None:
+        """Start the per-character location tracker if enabled."""
+        from argus_overview.intel.character_location import CharacterLocationTracker
+
+        enabled = self.settings_manager.get("intel.track_character_locations", True)
+        if not enabled:
+            self.location_tracker = None
+            return
+        self.location_tracker = CharacterLocationTracker(parent=self)
+        self.location_tracker.character_system_changed.connect(self._on_character_system_changed)
+        self.location_tracker.start()
+
+    @Slot(str, str)
+    def _on_character_system_changed(self, character_name: str, system: str) -> None:
+        """Forward per-character system updates to the dock + window manager."""
+        if not hasattr(self, "main_tab"):
+            return
+        wm = getattr(self.main_tab, "window_manager", None)
+        if wm is not None and hasattr(wm, "set_character_system"):
+            wm.set_character_system(character_name, system)
+        dock = getattr(self.main_tab, "status_dock", None)
+        if dock is not None and hasattr(dock, "set_character_system"):
+            dock.set_character_system(character_name, system)
 
     def _create_system_tray(self):
         """Create system tray icon (v2.4 - uses ActionRegistry)"""
@@ -1015,6 +1042,15 @@ class MainWindowV21(QMainWindow):
         # Stop systems
         if hasattr(self, "auto_discovery"):
             self.auto_discovery.stop()
+
+        if getattr(self, "location_tracker", None) is not None:
+            try:
+                self.location_tracker.character_system_changed.disconnect(
+                    self._on_character_system_changed
+                )
+            except (RuntimeError, TypeError):
+                pass
+            self.location_tracker.stop()
 
         if hasattr(self, "capture_system"):
             self.capture_system.stop()

--- a/src/argus_overview/ui/status_dock.py
+++ b/src/argus_overview/ui/status_dock.py
@@ -303,6 +303,24 @@ class StatusDock(QWidget):
         chip.set_system(system)
         return True
 
+    def set_character_system(self, character_name: str, system: str | None) -> int:
+        """
+        Update every chip for a given character. Returns count updated.
+
+        Multi-boxers can run the same character in multiple windows, so
+        chips are matched by character_name, not window_id. Source of the
+        update is typically CharacterLocationTracker.
+        """
+        count = 0
+        for chip in list(self._chips.values()):
+            try:
+                if chip.character_name == character_name:
+                    chip.set_system(system)
+                    count += 1
+            except RuntimeError:
+                continue
+        return count
+
     def sync_from_window_ids(self, desired: dict[str, str]) -> tuple[list[str], list[str]]:
         """
         Bulk diff: ensure chips match `desired` mapping of window_id -> name.

--- a/tests/test_character_location.py
+++ b/tests/test_character_location.py
@@ -1,0 +1,475 @@
+"""Tests for CharacterLocationTracker (PR4: per-character system tracking)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from argus_overview.intel.character_location import (
+    CharacterLocationTracker,
+    find_eve_chat_log_directory,
+)
+
+# Header block as EVE writes it, plus an initial Channel-changed line.
+_HEADER_TEMPLATE = (
+    "﻿"  # BOM stripped by utf-16-le decoding errors=ignore is fine
+    "---------------------------------------------------------------\r\n"
+    "  Channel ID:    Local\r\n"
+    "  Channel Name:  Local\r\n"
+    "  Listener:      {listener}\r\n"
+    "  Session Started: 2024.01.15 14:30:00\r\n"
+    "---------------------------------------------------------------\r\n"
+)
+
+
+def _write_local_log(
+    directory: Path,
+    listener: str,
+    lines: list[str] | None = None,
+    suffix: str = "20240115_143000",
+) -> Path:
+    """Write a UTF-16-LE Local log file with header + provided lines."""
+    content = _HEADER_TEMPLATE.format(listener=listener)
+    if lines:
+        content += "\r\n".join(lines) + "\r\n"
+    path = directory / f"Local_{suffix}.txt"
+    # Use 'utf-16' (with BOM) to match real EVE files; tracker uses utf-16-le
+    # with errors='ignore' which handles either.
+    path.write_bytes(content.encode("utf-16-le"))
+    return path
+
+
+def _append_local_log(path: Path, lines: list[str]) -> None:
+    """Append UTF-16-LE-encoded lines to an existing log file."""
+    addition = ("\r\n".join(lines) + "\r\n").encode("utf-16-le")
+    with open(path, "ab") as f:
+        f.write(addition)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+class TestFindEveChatLogDirectory:
+    def test_returns_first_existing(self, tmp_path):
+        # Manually patch Path.home to a directory layout where a candidate exists.
+        fake_home = tmp_path / "home"
+        chatlogs = fake_home / "Documents" / "EVE" / "logs" / "Chatlogs"
+        chatlogs.mkdir(parents=True)
+        with patch("argus_overview.intel.character_location.Path.home", return_value=fake_home):
+            result = find_eve_chat_log_directory()
+        assert result == chatlogs
+
+    def test_returns_none_when_no_candidates_exist(self, tmp_path):
+        fake_home = tmp_path / "no-eve"
+        fake_home.mkdir()
+        with patch("argus_overview.intel.character_location.Path.home", return_value=fake_home):
+            result = find_eve_chat_log_directory()
+        assert result is None
+
+
+# =============================================================================
+# Tracker — initial state
+# =============================================================================
+
+
+class TestCharacterLocationTrackerInit:
+    def test_initial_state_empty(self, qapp, tmp_path):
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        try:
+            assert tracker.get_all_locations() == {}
+            assert tracker.get_system("Anyone") is None
+            assert tracker.is_running() is False
+        finally:
+            tracker.deleteLater()
+
+    def test_poll_interval_clamped(self, qapp, tmp_path):
+        tracker = CharacterLocationTracker(log_directory=tmp_path, poll_interval_ms=10)
+        try:
+            assert tracker.poll_interval_ms == 250
+        finally:
+            tracker.deleteLater()
+
+
+# =============================================================================
+# Tracker — header + line parsing
+# =============================================================================
+
+
+class TestCharacterLocationTrackerParsing:
+    def test_listener_extracted_from_header(self, qapp, tmp_path):
+        path = _write_local_log(tmp_path, "TestPilot")
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        try:
+            listener = tracker._read_listener(path)
+            assert listener == "TestPilot"
+        finally:
+            tracker.deleteLater()
+
+    def test_listener_returns_none_for_missing_header(self, qapp, tmp_path):
+        path = tmp_path / "Local_20240115_140000.txt"
+        path.write_bytes("just chat data\r\n".encode("utf-16-le"))
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        try:
+            assert tracker._read_listener(path) is None
+        finally:
+            tracker.deleteLater()
+
+    def test_listener_with_special_characters(self, qapp, tmp_path):
+        path = _write_local_log(tmp_path, "Pilot O'Connor-Smith")
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        try:
+            assert tracker._read_listener(path) == "Pilot O'Connor-Smith"
+        finally:
+            tracker.deleteLater()
+
+    def test_channel_changed_emits_signal(self, qapp, tmp_path):
+        path = _write_local_log(tmp_path, "Alice")
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        received: list[tuple[str, str]] = []
+        tracker.character_system_changed.connect(lambda c, s: received.append((c, s)))
+        try:
+            # First scan establishes the file at end-of-file: no events.
+            tracker._poll()
+            assert received == []
+
+            _append_local_log(
+                path,
+                ["[ 2024.01.15 14:31:00 ] EVE System > Channel changed to Local : Jita"],
+            )
+            tracker._poll()
+            assert received == [("Alice", "Jita")]
+        finally:
+            tracker.deleteLater()
+
+    def test_channel_changed_dedupes_same_system(self, qapp, tmp_path):
+        path = _write_local_log(tmp_path, "Alice")
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        received: list[tuple[str, str]] = []
+        tracker.character_system_changed.connect(lambda c, s: received.append((c, s)))
+        try:
+            tracker._poll()
+            _append_local_log(
+                path,
+                [
+                    "[ 2024.01.15 14:31:00 ] EVE System > Channel changed to Local : Jita",
+                    "[ 2024.01.15 14:32:00 ] EVE System > Channel changed to Local : Jita",
+                ],
+            )
+            tracker._poll()
+            assert received == [("Alice", "Jita")]
+        finally:
+            tracker.deleteLater()
+
+    def test_channel_changed_emits_on_real_change(self, qapp, tmp_path):
+        path = _write_local_log(tmp_path, "Alice")
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        received: list[tuple[str, str]] = []
+        tracker.character_system_changed.connect(lambda c, s: received.append((c, s)))
+        try:
+            tracker._poll()
+            _append_local_log(
+                path,
+                ["[ 2024.01.15 14:31:00 ] EVE System > Channel changed to Local : Jita"],
+            )
+            tracker._poll()
+            _append_local_log(
+                path,
+                ["[ 2024.01.15 14:33:00 ] EVE System > Channel changed to Local : Amarr"],
+            )
+            tracker._poll()
+            assert received == [("Alice", "Jita"), ("Alice", "Amarr")]
+            assert tracker.get_system("Alice") == "Amarr"
+        finally:
+            tracker.deleteLater()
+
+    def test_unrelated_lines_ignored(self, qapp, tmp_path):
+        path = _write_local_log(tmp_path, "Alice")
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        received: list[tuple[str, str]] = []
+        tracker.character_system_changed.connect(lambda c, s: received.append((c, s)))
+        try:
+            tracker._poll()
+            _append_local_log(
+                path,
+                [
+                    "[ 2024.01.15 14:31:00 ] Bob > o7",
+                    "[ 2024.01.15 14:31:05 ] Carol > anyone home?",
+                ],
+            )
+            tracker._poll()
+            assert received == []
+        finally:
+            tracker.deleteLater()
+
+    def test_handles_file_truncation(self, qapp, tmp_path):
+        path = _write_local_log(tmp_path, "Alice")
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        try:
+            tracker._poll()  # Start at end-of-file
+            # Truncate the file (simulates rotation/recreation)
+            path.write_bytes(_HEADER_TEMPLATE.format(listener="Alice").encode("utf-16-le"))
+            # File is now smaller — tracker should reset cursor
+            tracker._poll()
+            _append_local_log(
+                path,
+                ["[ 2024.01.15 15:00:00 ] EVE System > Channel changed to Local : Dodixie"],
+            )
+            received: list[tuple[str, str]] = []
+            tracker.character_system_changed.connect(lambda c, s: received.append((c, s)))
+            tracker._poll()
+            assert received == [("Alice", "Dodixie")]
+        finally:
+            tracker.deleteLater()
+
+
+# =============================================================================
+# Tracker — multi-character
+# =============================================================================
+
+
+class TestCharacterLocationTrackerMultiChar:
+    def test_two_characters_tracked_independently(self, qapp, tmp_path):
+        a = _write_local_log(tmp_path, "Alice", suffix="20240115_140000")
+        b = _write_local_log(tmp_path, "Bob", suffix="20240115_140100")
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        try:
+            tracker._poll()  # establish cursors
+            _append_local_log(
+                a,
+                ["[ 2024.01.15 14:30:00 ] EVE System > Channel changed to Local : Jita"],
+            )
+            _append_local_log(
+                b,
+                ["[ 2024.01.15 14:30:01 ] EVE System > Channel changed to Local : Amarr"],
+            )
+            tracker._poll()
+            assert tracker.get_system("Alice") == "Jita"
+            assert tracker.get_system("Bob") == "Amarr"
+            assert tracker.get_all_locations() == {"Alice": "Jita", "Bob": "Amarr"}
+        finally:
+            tracker.deleteLater()
+
+    def test_files_without_listener_skipped(self, qapp, tmp_path):
+        # File without a Listener line — tracker should not crash and should
+        # not emit anything for it.
+        bad = tmp_path / "Local_20240115_140200.txt"
+        bad.write_bytes("garbage data\r\n".encode("utf-16-le"))
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        try:
+            tracker._poll()
+            tracker._poll()
+            assert tracker.get_all_locations() == {}
+        finally:
+            tracker.deleteLater()
+
+
+# =============================================================================
+# Tracker — lifecycle
+# =============================================================================
+
+
+class TestCharacterLocationTrackerLifecycle:
+    def test_start_no_directory_idles(self, qapp, tmp_path):
+        tracker = CharacterLocationTracker(log_directory=None)
+        try:
+            with patch(
+                "argus_overview.intel.character_location.find_eve_chat_log_directory",
+                return_value=None,
+            ):
+                tracker.start()
+            assert tracker.is_running() is False
+        finally:
+            tracker.deleteLater()
+
+    def test_start_with_directory_runs(self, qapp, tmp_path):
+        tracker = CharacterLocationTracker(log_directory=tmp_path, poll_interval_ms=500)
+        try:
+            tracker.start()
+            assert tracker.is_running() is True
+            tracker.stop()
+            assert tracker.is_running() is False
+        finally:
+            tracker.deleteLater()
+
+    def test_start_idempotent(self, qapp, tmp_path):
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        try:
+            tracker.start()
+            tracker.start()  # should not raise or restart
+            assert tracker.is_running() is True
+            tracker.stop()
+        finally:
+            tracker.deleteLater()
+
+    def test_stop_idempotent(self, qapp, tmp_path):
+        tracker = CharacterLocationTracker(log_directory=tmp_path)
+        try:
+            tracker.stop()  # never started
+            assert tracker.is_running() is False
+        finally:
+            tracker.deleteLater()
+
+
+# =============================================================================
+# StatusDock.set_character_system
+# =============================================================================
+
+
+class TestStatusDockSetCharacterSystem:
+    def test_updates_only_chips_for_named_character(self, qapp):
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            dock.add_chip("0x3", "Alice")  # multibox: Alice in two windows
+
+            count = dock.set_character_system("Alice", "Jita")
+
+            assert count == 2
+            assert dock._chips["0x1"]._system == "Jita"
+            assert dock._chips["0x3"]._system == "Jita"
+            assert dock._chips["0x2"]._system is None
+        finally:
+            dock.deleteLater()
+
+    def test_unknown_character_returns_zero(self, qapp):
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            count = dock.set_character_system("Nobody", "Jita")
+            assert count == 0
+        finally:
+            dock.deleteLater()
+
+
+# =============================================================================
+# WindowManager.set_character_system
+# =============================================================================
+
+
+class TestWindowManagerSetCharacterSystem:
+    def _make_manager(self):
+        from argus_overview.ui.main_tab import WindowManager
+
+        manager = WindowManager.__new__(WindowManager)
+        manager.preview_frames = {}
+        manager._character_systems = {}
+        return manager
+
+    def test_set_then_get(self):
+        manager = self._make_manager()
+        manager.set_character_system("Alice", "Jita")
+        assert manager.get_character_system("Alice") == "Jita"
+
+    def test_overwrite(self):
+        manager = self._make_manager()
+        manager.set_character_system("Alice", "Jita")
+        manager.set_character_system("Alice", "Amarr")
+        assert manager.get_character_system("Alice") == "Amarr"
+
+    def test_set_none_clears(self):
+        manager = self._make_manager()
+        manager.set_character_system("Alice", "Jita")
+        manager.set_character_system("Alice", None)
+        assert manager.get_character_system("Alice") is None
+
+    def test_unknown_character_returns_none(self):
+        manager = self._make_manager()
+        assert manager.get_character_system("Nobody") is None
+
+
+# =============================================================================
+# MainWindowV21 wiring
+# =============================================================================
+
+
+class TestMainWindowV21CharacterLocationWiring:
+    def test_on_character_system_changed_forwards_to_dock_and_manager(self):
+        from argus_overview.ui.main_window_v21 import MainWindowV21
+
+        window = MainWindowV21.__new__(MainWindowV21)
+        window.main_tab = MagicMock()
+        window.main_tab.window_manager = MagicMock()
+        window.main_tab.status_dock = MagicMock()
+
+        window._on_character_system_changed("Alice", "Jita")
+
+        window.main_tab.window_manager.set_character_system.assert_called_once_with("Alice", "Jita")
+        window.main_tab.status_dock.set_character_system.assert_called_once_with("Alice", "Jita")
+
+    def test_on_character_system_changed_no_main_tab_safe(self):
+        from argus_overview.ui.main_window_v21 import MainWindowV21
+
+        window = MainWindowV21.__new__(MainWindowV21)
+        # No main_tab set — should not raise
+        window._on_character_system_changed("Alice", "Jita")
+
+    def test_on_character_system_changed_dock_optional(self):
+        from argus_overview.ui.main_window_v21 import MainWindowV21
+
+        window = MainWindowV21.__new__(MainWindowV21)
+        window.main_tab = MagicMock(spec=["window_manager"])
+        window.main_tab.window_manager = MagicMock()
+
+        window._on_character_system_changed("Alice", "Jita")
+
+        window.main_tab.window_manager.set_character_system.assert_called_once()
+
+
+# =============================================================================
+# MainTab._sync_status_dock seeding
+# =============================================================================
+
+
+class TestMainTabSyncStatusDockSeedsSystem:
+    def test_sync_seeds_known_systems_into_chips(self):
+        from argus_overview.ui.main_tab import MainTab
+
+        tab = MainTab.__new__(MainTab)
+        tab.logger = MagicMock()
+        tab.window_manager = MagicMock()
+        tab.window_manager.preview_frames = {}
+        tab.window_manager._character_systems = {"Alice": "Jita", "Bob": "Amarr"}
+        tab.status_dock = MagicMock()
+
+        tab._sync_status_dock()
+
+        # Verify both characters were pushed into the dock for seeding
+        calls = tab.status_dock.set_character_system.call_args_list
+        seeded = {(c.args[0], c.args[1]) for c in calls}
+        assert seeded == {("Alice", "Jita"), ("Bob", "Amarr")}
+
+
+# =============================================================================
+# Additional safety: malformed lines
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "",
+        "garbage",
+        "[ bad timestamp ] EVE System > Channel changed to Local : Jita",
+        "[ 2024.01.15 14:31:00 ] EVE System > Some other message",
+        "[ 2024.01.15 14:31:00 ] Player > Channel changed to Local : Jita",
+    ],
+)
+def test_channel_changed_regex_rejects_garbage(qapp, tmp_path, line):
+    path = _write_local_log(tmp_path, "Alice")
+    tracker = CharacterLocationTracker(log_directory=tmp_path)
+    received: list[tuple[str, str]] = []
+    tracker.character_system_changed.connect(lambda c, s: received.append((c, s)))
+    try:
+        tracker._poll()
+        _append_local_log(path, [line])
+        tracker._poll()
+        assert received == []
+    finally:
+        tracker.deleteLater()

--- a/tests/test_main_window_v21.py
+++ b/tests/test_main_window_v21.py
@@ -2335,6 +2335,7 @@ class TestMainWindowV21InitPartial:
             stack.enter_context(patch.object(MainWindowV21, "_connect_signals"))
             stack.enter_context(patch.object(MainWindowV21, "_create_system_tray"))
             stack.enter_context(patch.object(MainWindowV21, "_register_hotkeys"))
+            stack.enter_context(patch.object(MainWindowV21, "_init_location_tracker"))
             stack.enter_context(patch(f"{mod}.QTabWidget"))
             stack.enter_context(patch(f"{mod}.QVBoxLayout"))
             stack.enter_context(patch(f"{mod}.QWidget"))


### PR DESCRIPTION
> **Stacked on #64 → #63 → #62.** Merge order: #62 → #63 → #64 → this. Each PR auto-retargets to \`main\` as its base merges.

## Summary
EVE writes a separate \`Local_*.txt\` chat log per character session. The header has a \`Listener:\` line naming the character; the body has \`Channel changed to Local : <System>\` lines whenever that character jumps. We parse both into a per-character current-system map.

## What's new
- **\`intel/character_location.py\`** — \`CharacterLocationTracker(QObject)\`:
  - Polls \`Local_*.txt\` files (UTF-16-LE) in the EVE chat log directory
  - Parses \`Listener:\` header once per file (4KB scan, regex)
  - Tails for \`Channel changed to Local : X\` and emits \`character_system_changed(char_name, system)\` only on real changes
  - File rotation/truncation handling, garbage-line rejection, idempotent start/stop
- **\`StatusDock.set_character_system\`** — updates every chip for a character (multibox-aware: same character in multiple windows all sync together)
- **\`WindowManager._character_systems\`** — persistent per-character map that survives window add/remove cycles
- **\`MainWindowV21._init_location_tracker\`** + \`_on_character_system_changed\` slot — forwards updates to dock + manager
- **\`MainTab._sync_status_dock\`** seeds chip systems from cached state so newly-imported windows populate without waiting

## Why this matters
This is the **architectural unlock** for chip-level / frame-level threat differentiation. Previously the parser tracked one global \`current_system\` (\`intel/parser.py:326\`) — every chip and frame shared it. Now each character has independent location state, so a future PR can tint only the frames whose character is in (or near) the affected system.

## Phase A — explicit scope
This PR ships the **tracker + UI sync of system labels** only. Smart per-character threat fan-out (filter \`apply_threat_state\` by character system) is deliberately a follow-up. The storage map exists; the fan-out semantics decision is parked until per-char tracking is observed in production.

## Test plan
- [x] 33 new tests in \`tests/test_character_location.py\` (header parsing, channel-changed line parsing, multi-character, file truncation, lifecycle, parametrized garbage-line rejection, dock + manager setters, MainWindowV21 wiring, MainTab seeding)
- [x] 1 existing test patched (\`test_init_creates_core_modules\` now also patches \`_init_location_tracker\`)
- [x] Full suite: **2289 passed, 5 skipped, 0 failures**
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Manual smoke: run with \`intel.track_character_locations=true\` while EVE is running, jump systems on multiple characters, verify each chip's system label updates independently

## Settings
- \`intel.track_character_locations\` — default \`true\`. Tracker idles if false or if no EVE log directory is found.

## Follow-ups (future PRs)
- **Smart fan-out**: \`apply_threat_state(level, system)\` → only tint frames whose character is in \`system\`, with a fallback for unknown locations
- **Jumps-from**: integrate \`JumpCalculator\` per-character so danger pulses on chips in adjacent systems too
- **Per-character accent border**: frame inherits chip's accent color when threat is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)