### PR TITLE
feat(ui): smart per-character threat fan-out

### DIFF
--- a/src/argus_overview/ui/main_tab.py
+++ b/src/argus_overview/ui/main_tab.py
@@ -628,6 +628,11 @@ class WindowPreviewWidget(QWidget):
         self._show_session_timer = False
         self._load_settings()
 
+        # PR4/PR5: known current system for this frame's character.
+        # Pushed by WindowManager.set_character_system; consumed by
+        # WindowManager.apply_threat_state for smart fan-out.
+        self._character_system: str | None = None
+
         # Intel threat state (PR1: intel-aware preview borders)
         self._threat_level: ThreatLevel | None = None
         self._threat_system: str | None = None
@@ -853,6 +858,13 @@ class WindowPreviewWidget(QWidget):
         self.opacity_effect.setOpacity(1.0)
 
         super().leaveEvent(event)
+
+    def set_character_system(self, system: str | None) -> None:
+        """Record the current system for this frame's character (PR5)."""
+        self._character_system = system
+
+    def get_character_system(self) -> str | None:
+        return self._character_system
 
     def set_threat_state(self, level: ThreatLevel | None, system: str | None = None) -> None:
         """
@@ -1240,33 +1252,78 @@ class WindowManager:
         """
         Record the current system for a character.
 
-        Stored on a per-character map (separate from preview_frames) so the
-        information survives across window add/remove cycles. PR4 uses this
-        only for storage + future smart fan-out; existing fan-out semantics
-        (one shared threat state) are unchanged.
+        Stored on a per-character map that survives across window add/remove
+        cycles, AND pushed to every active frame for that character so the
+        smart fan-out (apply_threat_state) can filter by frame state alone.
         """
         if system is None:
             self._character_systems.pop(character_name, None)
         else:
             self._character_systems[character_name] = system
 
+        # Push to active frames whose character matches.
+        for frame in list(self.preview_frames.values()):
+            try:
+                if getattr(frame, "character_name", None) == character_name:
+                    frame.set_character_system(system)
+            except RuntimeError:
+                continue
+
     def get_character_system(self, character_name: str) -> str | None:
         return self._character_systems.get(character_name)
 
     def apply_threat_state(self, level: ThreatLevel | None, system: str | None = None) -> int:
         """
-        Fan out an intel threat state to every preview frame.
+        Fan an intel threat state out to preview frames, filtered by system.
 
-        Until per-character system tracking lands, every frame shares the
-        same state. Returns the count of frames updated for tests + logs.
+        Filter rules (PR5 smart fan-out):
+          1. CLEAR or None level: flush every frame regardless of system.
+             Explicit clears must always win.
+          2. system is None / unknown: fall back to fanning all frames
+             (legacy behavior — preserves correctness when intel can't
+             attribute the report to a system).
+          3. Otherwise: only frames whose character's known system matches
+             the alert system. Frames whose character has no known system
+             fall through and still get tinted (graceful upgrade — until
+             every active character is being tracked, we don't want intel
+             to silently skip frames).
+
+        Returns count of frames actually updated for logs + tests.
         """
+        # Rule 1: clear path bypasses filter
+        if level is None or level == ThreatLevel.CLEAR:
+            return self._fan_to_all(level, system)
+
+        # Rule 2: no system to filter on
+        if not system:
+            return self._fan_to_all(level, system)
+
+        # Rule 3: filter by per-character known system. Lookup goes through
+        # _character_systems (the canonical map) rather than frame attrs so
+        # bypassed-init test helpers without per-char data fall through to
+        # the legacy "tint all" semantics.
+        char_systems = getattr(self, "_character_systems", {}) or {}
+        count = 0
+        for frame in list(self.preview_frames.values()):
+            try:
+                char_name = getattr(frame, "character_name", None)
+                known = char_systems.get(char_name) if char_name else None
+                # Known mismatch → skip; unknown or match → apply.
+                if known is not None and known != system:
+                    continue
+                frame.set_threat_state(level, system)
+                count += 1
+            except RuntimeError:
+                continue
+        return count
+
+    def _fan_to_all(self, level: ThreatLevel | None, system: str | None) -> int:
         count = 0
         for frame in list(self.preview_frames.values()):
             try:
                 frame.set_threat_state(level, system)
                 count += 1
             except RuntimeError:
-                # Widget already deleted by Qt — skip
                 continue
         return count
 

--- a/src/argus_overview/ui/status_dock.py
+++ b/src/argus_overview/ui/status_dock.py
@@ -286,10 +286,26 @@ class StatusDock(QWidget):
             self.remove_chip(window_id)
 
     def set_threat_state(self, level: ThreatLevel | None, system: str | None = None) -> int:
-        """Fan out a single threat state to every chip. Returns count updated."""
+        """
+        Fan a threat state out to chips, filtered by system (PR5 smart fan-out).
+
+        Mirrors WindowManager.apply_threat_state filter rules:
+          1. CLEAR / None level → flush every chip.
+          2. system is None / empty → fan to all (legacy fallback).
+          3. Otherwise → only chips whose tracked system matches, or whose
+             system is unknown (graceful upgrade until every chip has a
+             system from CharacterLocationTracker).
+
+        Returns count of chips updated.
+        """
         count = 0
+        flush = level is None or level == ThreatLevel.CLEAR or not system
         for chip in list(self._chips.values()):
             try:
+                if not flush:
+                    chip_system = getattr(chip, "_system", None)
+                    if chip_system is not None and chip_system != system:
+                        continue
                 chip.set_threat_state(level, system)
                 count += 1
             except RuntimeError:

--- a/tests/test_main_tab.py
+++ b/tests/test_main_tab.py
@@ -9666,3 +9666,280 @@ class TestMainTabFocusEscapeKey:
         except RuntimeError:
             pass  # Expected: super().keyPressEvent hits bypassed-init widget
         assert tab._focus_window_id is None
+
+
+# =============================================================================
+# Smart per-character threat fan-out (PR5)
+# =============================================================================
+
+
+def _frame_mock(character_name: str):
+    """Mock preview frame exposing the character_name + set_threat_state surface."""
+    f = MagicMock()
+    f.character_name = character_name
+    return f
+
+
+class TestWindowPreviewWidgetCharacterSystem:
+    """Tests for the per-frame _character_system setter."""
+
+    def test_set_and_get(self):
+        from argus_overview.ui.main_tab import WindowPreviewWidget
+
+        with patch.object(WindowPreviewWidget, "__init__", return_value=None):
+            widget = WindowPreviewWidget.__new__(WindowPreviewWidget)
+            widget._character_system = None
+
+            widget.set_character_system("Jita")
+            assert widget.get_character_system() == "Jita"
+
+            widget.set_character_system(None)
+            assert widget.get_character_system() is None
+
+
+class TestWindowManagerSetCharacterSystemPushesToFrames:
+    """set_character_system updates the map AND pushes to matching frames."""
+
+    def _make_manager(self):
+        from argus_overview.ui.main_tab import WindowManager
+
+        manager = WindowManager.__new__(WindowManager)
+        manager.preview_frames = {}
+        manager._character_systems = {}
+        return manager
+
+    def test_pushes_to_matching_frame_only(self):
+        manager = self._make_manager()
+        alice_frame = _frame_mock("Alice")
+        bob_frame = _frame_mock("Bob")
+        manager.preview_frames = {"w1": alice_frame, "w2": bob_frame}
+
+        manager.set_character_system("Alice", "Jita")
+
+        alice_frame.set_character_system.assert_called_once_with("Jita")
+        bob_frame.set_character_system.assert_not_called()
+
+    def test_pushes_to_multiple_frames_for_same_character(self):
+        manager = self._make_manager()
+        f1 = _frame_mock("Alice")
+        f2 = _frame_mock("Alice")
+        manager.preview_frames = {"w1": f1, "w2": f2}
+
+        manager.set_character_system("Alice", "Jita")
+
+        f1.set_character_system.assert_called_once_with("Jita")
+        f2.set_character_system.assert_called_once_with("Jita")
+
+    def test_clearing_character_pushes_none_to_frames(self):
+        manager = self._make_manager()
+        alice = _frame_mock("Alice")
+        manager.preview_frames = {"w1": alice}
+        manager._character_systems = {"Alice": "Jita"}
+
+        manager.set_character_system("Alice", None)
+
+        alice.set_character_system.assert_called_once_with(None)
+        assert "Alice" not in manager._character_systems
+
+    def test_skips_deleted_widgets(self):
+        manager = self._make_manager()
+        alive = _frame_mock("Alice")
+        dead = _frame_mock("Alice")
+        dead.set_character_system.side_effect = RuntimeError("widget deleted")
+        manager.preview_frames = {"alive": alive, "dead": dead}
+
+        # Should not raise even though one frame is gone.
+        manager.set_character_system("Alice", "Jita")
+
+        alive.set_character_system.assert_called_once_with("Jita")
+
+
+class TestWindowManagerApplyThreatStateSmartFanout:
+    """PR5 smart fan-out filter rules."""
+
+    def _make_manager(self, char_systems: dict[str, str] | None = None):
+        from argus_overview.ui.main_tab import WindowManager
+
+        manager = WindowManager.__new__(WindowManager)
+        manager.preview_frames = {}
+        manager._character_systems = dict(char_systems or {})
+        return manager
+
+    def test_clear_flushes_all_regardless_of_system(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(char_systems={"Alice": "Jita", "Bob": "Amarr"})
+        alice = _frame_mock("Alice")
+        bob = _frame_mock("Bob")
+        manager.preview_frames = {"w1": alice, "w2": bob}
+
+        count = manager.apply_threat_state(ThreatLevel.CLEAR, "HED-GP")
+
+        assert count == 2
+        alice.set_threat_state.assert_called_once_with(ThreatLevel.CLEAR, "HED-GP")
+        bob.set_threat_state.assert_called_once_with(ThreatLevel.CLEAR, "HED-GP")
+
+    def test_none_level_flushes_all(self):
+        manager = self._make_manager(char_systems={"Alice": "Jita"})
+        alice = _frame_mock("Alice")
+        manager.preview_frames = {"w1": alice}
+
+        count = manager.apply_threat_state(None, "HED-GP")
+
+        assert count == 1
+        alice.set_threat_state.assert_called_once()
+
+    def test_no_alert_system_falls_through_to_all(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(char_systems={"Alice": "Jita"})
+        alice = _frame_mock("Alice")
+        bob = _frame_mock("Bob")
+        manager.preview_frames = {"w1": alice, "w2": bob}
+
+        count = manager.apply_threat_state(ThreatLevel.WARNING, None)
+
+        assert count == 2
+
+    def test_empty_alert_system_falls_through_to_all(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(char_systems={"Alice": "Jita"})
+        alice = _frame_mock("Alice")
+        manager.preview_frames = {"w1": alice}
+
+        count = manager.apply_threat_state(ThreatLevel.WARNING, "")
+
+        assert count == 1
+
+    def test_only_matching_character_tints(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(char_systems={"Alice": "HED-GP", "Bob": "Amarr"})
+        alice = _frame_mock("Alice")
+        bob = _frame_mock("Bob")
+        manager.preview_frames = {"w1": alice, "w2": bob}
+
+        count = manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        assert count == 1
+        alice.set_threat_state.assert_called_once_with(ThreatLevel.DANGER, "HED-GP")
+        bob.set_threat_state.assert_not_called()
+
+    def test_unknown_character_falls_through_to_apply(self):
+        """Graceful upgrade: untracked characters still tint."""
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(char_systems={"Alice": "HED-GP"})
+        alice = _frame_mock("Alice")
+        bob = _frame_mock("Bob")  # Bob has no known system
+        manager.preview_frames = {"w1": alice, "w2": bob}
+
+        count = manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        assert count == 2
+        alice.set_threat_state.assert_called_once()
+        bob.set_threat_state.assert_called_once()
+
+    def test_no_per_char_data_fans_to_all_legacy_behavior(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(char_systems={})
+        f1 = _frame_mock("Alice")
+        f2 = _frame_mock("Bob")
+        manager.preview_frames = {"w1": f1, "w2": f2}
+
+        count = manager.apply_threat_state(ThreatLevel.WARNING, "HED-GP")
+
+        assert count == 2
+
+    def test_skips_deleted_widgets(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(char_systems={"Alice": "HED-GP"})
+        alive = _frame_mock("Alice")
+        dead = _frame_mock("Alice")
+        dead.set_threat_state.side_effect = RuntimeError("widget deleted")
+        manager.preview_frames = {"alive": alive, "dead": dead}
+
+        count = manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        assert count == 1
+
+
+class TestStatusDockSmartFanout:
+    """PR5 smart fan-out applied to chips via their _system attribute."""
+
+    def test_only_matching_chips_tint(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            dock.set_character_system("Alice", "HED-GP")
+            dock.set_character_system("Bob", "Amarr")
+
+            count = dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+            assert count == 1
+            assert dock._chips["0x1"]._threat_level == ThreatLevel.DANGER
+            assert dock._chips["0x2"]._threat_level is None
+        finally:
+            dock.deleteLater()
+
+    def test_unknown_chip_falls_through(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")  # Bob has no system
+            dock.set_character_system("Alice", "HED-GP")
+
+            count = dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+            # Both tint: Alice matches, Bob unknown → graceful fallback.
+            assert count == 2
+        finally:
+            dock.deleteLater()
+
+    def test_clear_bypasses_filter(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            dock.set_character_system("Alice", "HED-GP")
+            dock.set_character_system("Bob", "Amarr")
+            # Tint both first
+            dock._chips["0x1"].set_threat_state(ThreatLevel.DANGER, "HED-GP")
+            dock._chips["0x2"].set_threat_state(ThreatLevel.WARNING, "Amarr")
+
+            count = dock.set_threat_state(ThreatLevel.CLEAR, "HED-GP")
+
+            assert count == 2
+            for chip in dock._chips.values():
+                assert chip._threat_level is None
+        finally:
+            dock.deleteLater()
+
+    def test_no_system_fans_to_all(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            dock.set_character_system("Alice", "Jita")
+            dock.set_character_system("Bob", "Amarr")
+
+            count = dock.set_threat_state(ThreatLevel.WARNING, None)
+            assert count == 2
+        finally:
+            dock.deleteLater()


### PR DESCRIPTION
> **Stacked on #65 → #64 → #63 → #62.** Merge order: 62 → 63 → 64 → 65 → this. Auto-retargeting handles the chain.

## Summary
This is the **payoff PR** for the four that came before. Threat alerts now tint only the frames + chips for characters who are actually in the affected system. EVE-O Preview cannot do this — it has no awareness of which client is in which system.

## Filter rules (symmetric in WindowManager + StatusDock)
1. **CLEAR / None level**: flush every frame regardless of system. Explicit clears must always win.
2. **\`system\` is None / empty**: fan to all (legacy fallback — preserves correctness when intel can't attribute the report to a system).
3. **Otherwise**: only frames whose character's known system matches the alert system. Frames whose character has no known system **fall through and still tint** (graceful upgrade — until every active character is being tracked, intel must not silently skip frames).

## What's new
- \`WindowPreviewWidget._character_system\` + \`set_character_system\` / \`get_character_system\`
- \`WindowManager.set_character_system\` now also pushes the system to every matching active frame, not just the internal map
- \`WindowManager.apply_threat_state\` filters via \`_character_systems\` lookup by \`frame.character_name\` (deliberately not via frame attr — bypassed-init test helpers fall through cleanly)
- \`StatusDock.set_threat_state\` filters via \`chip._system\` (chip already stored this from #65)
- New private helper \`_fan_to_all\` for the explicit-flush branches

## The composite UX moment
> "hostiles HED-GP +3" fires → only the frame for the character in HED-GP pulses red → the chip for that character lights up red → user double-clicks the frame to spotlight (#64) → others stay dim and quiet.

## Test plan
- [x] 17 new tests:
  - \`TestWindowPreviewWidgetCharacterSystem\` — set/get on the widget
  - \`TestWindowManagerSetCharacterSystemPushesToFrames\` — push to matching, multibox, clear, deleted-widget skip
  - \`TestWindowManagerApplyThreatStateSmartFanout\` — clear bypasses filter, None level flushes, no system falls through, only matching tints, unknown char graceful fallback, no per-char data legacy behavior, deleted skip
  - \`TestStatusDockSmartFanout\` — match-only, unknown fallthrough, clear bypass, no-system fallthrough
- [x] All existing PR1/PR4 fan-out tests still pass (default \`_character_systems = {}\` triggers legacy path)
- [x] Full suite: **2306 passed, 5 skipped, 0 failures**
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Manual smoke: run with multiple EVE clients in different systems, fire a test alert, verify only the matching pilot's frame + chip pulse

## Follow-ups (future PRs, not in this one)
- **Jumps-from filter**: integrate \`JumpCalculator\` so danger pulses also fire on chips/frames within N jumps of the alert system, with reduced intensity
- **Per-character accent border**: frame border inherits chip accent when threat is clear (identification at small sizes)
- **Workspace minimap**: bird's-eye dot map of dock+grid in a corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)