### PR TITLE
feat(intel): jumps-from threat fan-out with adjacency falloff

### DIFF
--- a/src/argus_overview/intel/threat_filter.py
+++ b/src/argus_overview/intel/threat_filter.py
@@ -1,0 +1,75 @@
+"""
+Threat fan-out filter — resolves whether a frame/chip should tint for an
+incoming intel alert, and at what intensity.
+
+Used by both WindowManager.apply_threat_state and StatusDock.set_threat_state
+so the per-character tinting rules stay symmetric across the preview grid
+and the chip strip.
+
+PR6 of the intel-aware UI uplift.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argus_overview.intel.jumps import JumpCalculator
+
+
+# Alpha falloff: same-system = 1.0, each additional jump multiplies by this
+# until we hit the floor or exceed max_jumps.
+_PER_JUMP_FALLOFF = 0.5
+# Absolute floor for adjacent-system alerts so they remain visible.
+_MIN_ADJACENT_ALPHA = 0.4
+
+
+def resolve_tint(
+    known_system: str | None,
+    alert_system: str | None,
+    jump_calculator: JumpCalculator | None = None,
+    max_jumps: int = 0,
+) -> tuple[bool, float]:
+    """
+    Decide whether a frame/chip should tint for an alert, and at what alpha.
+
+    Args:
+        known_system: The character's last-known current system. None if
+            we don't have a per-character location yet.
+        alert_system: The system the intel report refers to. None if intel
+            couldn't attribute the report to a system.
+        jump_calculator: Optional graph for adjacency lookups. When None,
+            only exact matches and the unknown-fallthrough rules apply.
+        max_jumps: Maximum jump distance to consider "near". Zero means
+            exact-match only (PR5 behavior).
+
+    Returns:
+        (should_apply, alpha)
+            should_apply: True if the frame/chip should call set_threat_state
+            alpha: Initial alpha in [0.0, 1.0]; same-system = 1.0,
+                   each jump out scales down by _PER_JUMP_FALLOFF
+                   with a floor of _MIN_ADJACENT_ALPHA.
+    """
+    # No known location → graceful fallback (apply at full intensity).
+    if known_system is None:
+        return True, 1.0
+
+    # No alert system to match against → fallback (apply at full).
+    if not alert_system:
+        return True, 1.0
+
+    # Same system → full intensity, no calculator needed.
+    if known_system.lower() == alert_system.lower():
+        return True, 1.0
+
+    # Need a calculator + non-zero threshold to consider adjacency.
+    if jump_calculator is None or max_jumps <= 0:
+        return False, 0.0
+
+    distance = jump_calculator.distance(known_system, alert_system)
+    if distance is None or distance > max_jumps:
+        return False, 0.0
+
+    # Adjacent within threshold — scale alpha down by distance.
+    alpha = max(_MIN_ADJACENT_ALPHA, _PER_JUMP_FALLOFF**distance)
+    return True, alpha

--- a/src/argus_overview/ui/main_tab.py
+++ b/src/argus_overview/ui/main_tab.py
@@ -866,13 +866,22 @@ class WindowPreviewWidget(QWidget):
     def get_character_system(self) -> str | None:
         return self._character_system
 
-    def set_threat_state(self, level: ThreatLevel | None, system: str | None = None) -> None:
+    def set_threat_state(
+        self,
+        level: ThreatLevel | None,
+        system: str | None = None,
+        initial_alpha: float = 1.0,
+    ) -> None:
         """
         Update the intel threat state for this preview frame.
 
         Args:
             level: Threat level. None or CLEAR clears the border.
             system: System name the threat refers to (kept for tooltip + dock).
+            initial_alpha: Starting alpha [0.0, 1.0] for the border. Defaults
+                to 1.0 (full intensity for same-system alerts). Lower values
+                are used by WindowManager when fanning to characters in
+                adjacent systems via the jumps-from filter (PR6).
         """
         prev_level = self._threat_level
 
@@ -886,13 +895,18 @@ class WindowPreviewWidget(QWidget):
 
         self._threat_level = level
         self._threat_system = system
-        self._threat_alpha = 1.0
+        self._threat_alpha = max(0.0, min(1.0, initial_alpha))
 
-        # Pulse on upgrade into danger/critical
+        # Pulse on upgrade into danger/critical (only at full-ish intensity —
+        # don't pulse for distant adjacent-system alerts).
         upgraded = prev_level is None or THREAT_LEVEL_RANK.get(
             prev_level, 0
         ) < THREAT_LEVEL_RANK.get(level, 0)
-        if upgraded and level in (ThreatLevel.DANGER, ThreatLevel.CRITICAL):
+        if (
+            upgraded
+            and level in (ThreatLevel.DANGER, ThreatLevel.CRITICAL)
+            and initial_alpha >= 0.9
+        ):
             self._start_pulse()
 
         # Restart decay timer
@@ -1168,6 +1182,11 @@ class WindowManager:
         # Survives window add/remove cycles. Used for chip system labels and
         # (in a follow-up PR) smart per-character threat fan-out.
         self._character_systems: dict[str, str] = {}
+        # PR6: optional jump calculator + max-jumps threshold for the
+        # adjacency-aware fan-out. Default max_jumps=0 preserves the PR5
+        # exact-match-only filter when no calculator is wired up.
+        self._jump_calculator = None  # type: ignore[var-annotated]
+        self._jump_max: int = 0
         self.pending_requests: dict[
             str, tuple[str, float]
         ] = {}  # request_id -> (window_id, timestamp)
@@ -1272,46 +1291,55 @@ class WindowManager:
     def get_character_system(self, character_name: str) -> str | None:
         return self._character_systems.get(character_name)
 
+    def set_jump_calculator(self, calculator, max_jumps: int = 1) -> None:
+        """
+        Wire an adjacency calculator for the jumps-from threat filter (PR6).
+
+        Args:
+            calculator: A JumpCalculator (or None to disable adjacency).
+            max_jumps: Maximum jump distance to consider "near"; 0 disables
+                adjacency tinting (exact-match-only). Default 1.
+        """
+        self._jump_calculator = calculator
+        self._jump_max = max(0, int(max_jumps))
+
     def apply_threat_state(self, level: ThreatLevel | None, system: str | None = None) -> int:
         """
         Fan an intel threat state out to preview frames, filtered by system.
 
-        Filter rules (PR5 smart fan-out):
-          1. CLEAR or None level: flush every frame regardless of system.
-             Explicit clears must always win.
-          2. system is None / unknown: fall back to fanning all frames
-             (legacy behavior — preserves correctness when intel can't
-             attribute the report to a system).
-          3. Otherwise: only frames whose character's known system matches
-             the alert system. Frames whose character has no known system
-             fall through and still get tinted (graceful upgrade — until
-             every active character is being tracked, we don't want intel
-             to silently skip frames).
+        Filter rules:
+          1. CLEAR / None level → flush every frame regardless of system.
+          2. system is None / empty → fan to all (legacy fallback).
+          3. Otherwise → resolve_tint() decides per-frame: same-system at
+             full alpha, adjacent within max_jumps at falloff alpha,
+             beyond threshold skipped, unknown character system tinted at
+             full alpha (graceful upgrade).
 
-        Returns count of frames actually updated for logs + tests.
+        Returns count of frames actually updated.
         """
-        # Rule 1: clear path bypasses filter
-        if level is None or level == ThreatLevel.CLEAR:
+        from argus_overview.intel.threat_filter import resolve_tint
+
+        # Rule 1 + 2: explicit-flush branches
+        if level is None or level == ThreatLevel.CLEAR or not system:
             return self._fan_to_all(level, system)
 
-        # Rule 2: no system to filter on
-        if not system:
-            return self._fan_to_all(level, system)
-
-        # Rule 3: filter by per-character known system. Lookup goes through
-        # _character_systems (the canonical map) rather than frame attrs so
-        # bypassed-init test helpers without per-char data fall through to
-        # the legacy "tint all" semantics.
         char_systems = getattr(self, "_character_systems", {}) or {}
+        calculator = getattr(self, "_jump_calculator", None)
+        max_jumps = getattr(self, "_jump_max", 0)
         count = 0
         for frame in list(self.preview_frames.values()):
             try:
                 char_name = getattr(frame, "character_name", None)
                 known = char_systems.get(char_name) if char_name else None
-                # Known mismatch → skip; unknown or match → apply.
-                if known is not None and known != system:
+                should_apply, alpha = resolve_tint(
+                    known_system=known,
+                    alert_system=system,
+                    jump_calculator=calculator,
+                    max_jumps=max_jumps,
+                )
+                if not should_apply:
                     continue
-                frame.set_threat_state(level, system)
+                frame.set_threat_state(level, system, initial_alpha=alpha)
                 count += 1
             except RuntimeError:
                 continue

--- a/src/argus_overview/ui/main_window_v21.py
+++ b/src/argus_overview/ui/main_window_v21.py
@@ -178,6 +178,29 @@ class MainWindowV21(QMainWindow):
         self.location_tracker.character_system_changed.connect(self._on_character_system_changed)
         self.location_tracker.start()
 
+        # PR6: wire one shared JumpCalculator into both threat fan-out paths
+        # so adjacent-system alerts also tint at reduced intensity. max_jumps
+        # is gated on intel.threat_jumps_threshold (default 1).
+        self._init_threat_jump_filter()
+
+    def _init_threat_jump_filter(self) -> None:
+        """Wire a shared JumpCalculator into the manager + dock fan-out."""
+        from argus_overview.intel.jumps import JumpCalculator
+
+        max_jumps = int(self.settings_manager.get("intel.threat_jumps_threshold", 1))
+        if max_jumps <= 0:
+            self.jump_calculator = None
+            return
+        self.jump_calculator = JumpCalculator()
+        if not hasattr(self, "main_tab"):
+            return
+        wm = getattr(self.main_tab, "window_manager", None)
+        if wm is not None and hasattr(wm, "set_jump_calculator"):
+            wm.set_jump_calculator(self.jump_calculator, max_jumps=max_jumps)
+        dock = getattr(self.main_tab, "status_dock", None)
+        if dock is not None and hasattr(dock, "set_jump_calculator"):
+            dock.set_jump_calculator(self.jump_calculator, max_jumps=max_jumps)
+
     @Slot(str, str)
     def _on_character_system_changed(self, character_name: str, system: str) -> None:
         """Forward per-character system updates to the dock + window manager."""

--- a/src/argus_overview/ui/status_dock.py
+++ b/src/argus_overview/ui/status_dock.py
@@ -226,6 +226,10 @@ class StatusDock(QWidget):
         super().__init__(parent)
         self.logger = logging.getLogger(__name__)
         self._chips: dict[str, CharacterChip] = {}
+        # PR6 jumps-from filter — set via set_jump_calculator. Default
+        # max_jumps=0 keeps the PR5 exact-match-only behavior.
+        self._jump_calculator = None
+        self._jump_max: int = 0
 
         self.setFixedHeight(56)
         outer = QVBoxLayout(self)
@@ -285,28 +289,46 @@ class StatusDock(QWidget):
         for window_id in list(self._chips.keys()):
             self.remove_chip(window_id)
 
+    def set_jump_calculator(self, calculator, max_jumps: int = 1) -> None:
+        """Wire an adjacency calculator for the jumps-from filter (PR6)."""
+        self._jump_calculator = calculator
+        self._jump_max = max(0, int(max_jumps))
+
     def set_threat_state(self, level: ThreatLevel | None, system: str | None = None) -> int:
         """
-        Fan a threat state out to chips, filtered by system (PR5 smart fan-out).
+        Fan a threat state out to chips, filtered by system.
 
-        Mirrors WindowManager.apply_threat_state filter rules:
+        Filter rules (mirror WindowManager.apply_threat_state for symmetry):
           1. CLEAR / None level → flush every chip.
           2. system is None / empty → fan to all (legacy fallback).
-          3. Otherwise → only chips whose tracked system matches, or whose
-             system is unknown (graceful upgrade until every chip has a
-             system from CharacterLocationTracker).
+          3. Otherwise → resolve_tint() per chip. Same-system at full alpha,
+             adjacent within max_jumps at falloff alpha, beyond skipped,
+             unknown chip-system tinted at full alpha (graceful upgrade).
 
         Returns count of chips updated.
         """
-        count = 0
+        from argus_overview.intel.threat_filter import resolve_tint
+
         flush = level is None or level == ThreatLevel.CLEAR or not system
+        count = 0
+        calculator = getattr(self, "_jump_calculator", None)
+        max_jumps = getattr(self, "_jump_max", 0)
         for chip in list(self._chips.values()):
             try:
-                if not flush:
-                    chip_system = getattr(chip, "_system", None)
-                    if chip_system is not None and chip_system != system:
-                        continue
-                chip.set_threat_state(level, system)
+                if flush:
+                    chip.set_threat_state(level, system)
+                    count += 1
+                    continue
+                chip_system = getattr(chip, "_system", None)
+                should_apply, alpha = resolve_tint(
+                    known_system=chip_system,
+                    alert_system=system,
+                    jump_calculator=calculator,
+                    max_jumps=max_jumps,
+                )
+                if not should_apply:
+                    continue
+                chip.set_threat_state(level, system, alpha=alpha)
                 count += 1
             except RuntimeError:
                 continue

--- a/tests/test_main_tab.py
+++ b/tests/test_main_tab.py
@@ -9260,9 +9260,17 @@ class TestWindowManagerApplyThreatState:
             count = manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
 
             assert count == 3
-            f1.set_threat_state.assert_called_once_with(ThreatLevel.DANGER, "HED-GP")
-            f2.set_threat_state.assert_called_once_with(ThreatLevel.DANGER, "HED-GP")
-            f3.set_threat_state.assert_called_once_with(ThreatLevel.DANGER, "HED-GP")
+            # PR6: smart-filter branch passes initial_alpha=1.0 explicitly when
+            # the per-character system is unknown (graceful fallback).
+            f1.set_threat_state.assert_called_once_with(
+                ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+            )
+            f2.set_threat_state.assert_called_once_with(
+                ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+            )
+            f3.set_threat_state.assert_called_once_with(
+                ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+            )
 
     def test_apply_threat_state_empty_frames(self):
         from argus_overview.intel.parser import ThreatLevel
@@ -9823,7 +9831,9 @@ class TestWindowManagerApplyThreatStateSmartFanout:
         count = manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
 
         assert count == 1
-        alice.set_threat_state.assert_called_once_with(ThreatLevel.DANGER, "HED-GP")
+        alice.set_threat_state.assert_called_once_with(
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+        )
         bob.set_threat_state.assert_not_called()
 
     def test_unknown_character_falls_through_to_apply(self):
@@ -9941,5 +9951,251 @@ class TestStatusDockSmartFanout:
 
             count = dock.set_threat_state(ThreatLevel.WARNING, None)
             assert count == 2
+        finally:
+            dock.deleteLater()
+
+
+# =============================================================================
+# Jumps-from threat fan-out (PR6)
+# =============================================================================
+
+
+class TestWindowPreviewWidgetInitialAlpha:
+    """set_threat_state honors the initial_alpha param."""
+
+    def _make_widget(self, qapp):
+        from argus_overview.ui.main_tab import WindowPreviewWidget
+
+        return WindowPreviewWidget(
+            window_id="0xABC",
+            character_name="TestPilot",
+            capture_system=MagicMock(),
+        )
+
+    def test_default_alpha_is_one(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.set_threat_state(ThreatLevel.WARNING, "Jita")
+            assert widget._threat_alpha == 1.0
+        finally:
+            widget.deleteLater()
+
+    def test_explicit_alpha_applied(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.set_threat_state(ThreatLevel.WARNING, "Jita", initial_alpha=0.5)
+            assert widget._threat_alpha == 0.5
+        finally:
+            widget.deleteLater()
+
+    def test_alpha_clamped_to_unit_range(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.set_threat_state(ThreatLevel.WARNING, "Jita", initial_alpha=2.5)
+            assert widget._threat_alpha == 1.0
+            widget.set_threat_state(ThreatLevel.WARNING, "Jita", initial_alpha=-0.5)
+            assert widget._threat_alpha == 0.0
+        finally:
+            widget.deleteLater()
+
+    def test_pulse_skipped_for_low_alpha_alerts(self, qapp):
+        """Adjacent-system alerts (low alpha) should NOT pulse."""
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.set_threat_state(ThreatLevel.DANGER, "Jita", initial_alpha=0.5)
+            assert widget._pulse_phase == 0.0
+        finally:
+            widget.deleteLater()
+
+    def test_pulse_fires_for_full_alpha_danger(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.set_threat_state(ThreatLevel.DANGER, "Jita", initial_alpha=1.0)
+            assert widget._pulse_phase == 1.0
+        finally:
+            widget.deleteLater()
+
+
+def _calc_mock(distances: dict[tuple[str, str], int | None]):
+    """Build a MagicMock JumpCalculator from a (from, to) -> distance map."""
+    calc = MagicMock()
+
+    def _distance(a, b):
+        return distances.get((a, b)) or distances.get((b, a))
+
+    calc.distance.side_effect = _distance
+    return calc
+
+
+class TestWindowManagerJumpsFromFanout:
+    """WindowManager.apply_threat_state with jumps-from filter."""
+
+    def _make_manager(
+        self,
+        char_systems: dict[str, str],
+        max_jumps: int = 0,
+        distances: dict[tuple[str, str], int | None] | None = None,
+    ):
+        from argus_overview.ui.main_tab import WindowManager
+
+        manager = WindowManager.__new__(WindowManager)
+        manager.preview_frames = {}
+        manager._character_systems = dict(char_systems)
+        manager._jump_calculator = _calc_mock(distances or {}) if distances else None
+        manager._jump_max = max_jumps
+        return manager
+
+    def test_set_jump_calculator_stores_calculator_and_max(self):
+        from argus_overview.ui.main_tab import WindowManager
+
+        manager = WindowManager.__new__(WindowManager)
+        calc = MagicMock()
+
+        manager.set_jump_calculator(calc, max_jumps=3)
+
+        assert manager._jump_calculator is calc
+        assert manager._jump_max == 3
+
+    def test_set_jump_calculator_clamps_negative_max(self):
+        from argus_overview.ui.main_tab import WindowManager
+
+        manager = WindowManager.__new__(WindowManager)
+        manager.set_jump_calculator(MagicMock(), max_jumps=-5)
+
+        assert manager._jump_max == 0
+
+    def test_adjacent_character_tinted_with_falloff_alpha(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(
+            char_systems={"Alice": "Jita", "Bob": "HED-GP"},
+            max_jumps=2,
+            distances={("Jita", "HED-GP"): 1, ("HED-GP", "HED-GP"): 0},
+        )
+        alice = _frame_mock("Alice")
+        bob = _frame_mock("Bob")
+        manager.preview_frames = {"w1": alice, "w2": bob}
+
+        count = manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        assert count == 2
+        bob.set_threat_state.assert_called_once_with(
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+        )
+        alice.set_threat_state.assert_called_once_with(
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=0.5
+        )
+
+    def test_beyond_threshold_skipped(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(
+            char_systems={"Alice": "Jita"},
+            max_jumps=1,
+            distances={("Jita", "HED-GP"): 4},
+        )
+        alice = _frame_mock("Alice")
+        manager.preview_frames = {"w1": alice}
+
+        count = manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        assert count == 0
+        alice.set_threat_state.assert_not_called()
+
+    def test_no_calculator_keeps_pr5_exact_match_only(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        manager = self._make_manager(char_systems={"Alice": "Jita", "Bob": "HED-GP"}, max_jumps=0)
+        alice = _frame_mock("Alice")
+        bob = _frame_mock("Bob")
+        manager.preview_frames = {"w1": alice, "w2": bob}
+
+        count = manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        assert count == 1
+        bob.set_threat_state.assert_called_once()
+        alice.set_threat_state.assert_not_called()
+
+
+class TestStatusDockJumpsFromFanout:
+    """StatusDock.set_threat_state with jumps-from filter."""
+
+    def test_set_jump_calculator_stores_calculator_and_max(self, qapp):
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            calc = MagicMock()
+            dock.set_jump_calculator(calc, max_jumps=2)
+            assert dock._jump_calculator is calc
+            assert dock._jump_max == 2
+        finally:
+            dock.deleteLater()
+
+    def test_adjacent_chip_tinted_with_falloff_alpha(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            calc = _calc_mock({("Jita", "HED-GP"): 1})
+            dock.set_jump_calculator(calc, max_jumps=2)
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            dock.set_character_system("Alice", "Jita")
+            dock.set_character_system("Bob", "HED-GP")
+
+            count = dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+            assert count == 2
+            assert dock._chips["0x2"]._threat_alpha == 1.0
+            assert dock._chips["0x1"]._threat_alpha == 0.5
+        finally:
+            dock.deleteLater()
+
+    def test_beyond_threshold_chip_skipped(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            calc = _calc_mock({("Jita", "HED-GP"): 5})
+            dock.set_jump_calculator(calc, max_jumps=1)
+            dock.add_chip("0x1", "Alice")
+            dock.set_character_system("Alice", "Jita")
+
+            count = dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+            assert count == 0
+            assert dock._chips["0x1"]._threat_level is None
+        finally:
+            dock.deleteLater()
+
+    def test_no_calculator_keeps_pr5_behavior(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.add_chip("0x1", "Alice")
+            dock.add_chip("0x2", "Bob")
+            dock.set_character_system("Alice", "Jita")
+            dock.set_character_system("Bob", "HED-GP")
+
+            count = dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+            assert count == 1
+            assert dock._chips["0x2"]._threat_level is not None
+            assert dock._chips["0x1"]._threat_level is None
         finally:
             dock.deleteLater()

--- a/tests/test_threat_filter.py
+++ b/tests/test_threat_filter.py
@@ -1,0 +1,111 @@
+"""Tests for intel/threat_filter.resolve_tint helper (PR6)."""
+
+from unittest.mock import MagicMock
+
+from argus_overview.intel.threat_filter import resolve_tint
+
+
+class TestResolveTintExplicitFlush:
+    """Cases where the helper falls through to apply at full alpha."""
+
+    def test_unknown_character_falls_through_full(self):
+        should, alpha = resolve_tint(known_system=None, alert_system="HED-GP")
+        assert should is True
+        assert alpha == 1.0
+
+    def test_no_alert_system_falls_through_full(self):
+        should, alpha = resolve_tint(known_system="Jita", alert_system=None)
+        assert should is True
+        assert alpha == 1.0
+
+    def test_empty_alert_system_falls_through_full(self):
+        should, alpha = resolve_tint(known_system="Jita", alert_system="")
+        assert should is True
+        assert alpha == 1.0
+
+
+class TestResolveTintExactMatch:
+    def test_same_system_full_alpha(self):
+        should, alpha = resolve_tint(known_system="HED-GP", alert_system="HED-GP")
+        assert should is True
+        assert alpha == 1.0
+
+    def test_case_insensitive_match(self):
+        should, alpha = resolve_tint(known_system="hed-gp", alert_system="HED-GP")
+        assert should is True
+        assert alpha == 1.0
+
+
+class TestResolveTintAdjacency:
+    """Cases that need a JumpCalculator + non-zero max_jumps."""
+
+    def test_no_calculator_skips_mismatch(self):
+        should, alpha = resolve_tint(
+            known_system="Amarr", alert_system="HED-GP", jump_calculator=None
+        )
+        assert should is False
+        assert alpha == 0.0
+
+    def test_zero_max_jumps_skips_mismatch_even_with_calculator(self):
+        calc = MagicMock()
+        calc.distance.return_value = 1
+        should, alpha = resolve_tint(
+            known_system="Amarr",
+            alert_system="HED-GP",
+            jump_calculator=calc,
+            max_jumps=0,
+        )
+        assert should is False
+        # Calculator should NOT have been queried — max_jumps=0 short-circuits
+        calc.distance.assert_not_called()
+
+    def test_one_jump_within_threshold_uses_falloff_alpha(self):
+        calc = MagicMock()
+        calc.distance.return_value = 1
+        should, alpha = resolve_tint(
+            known_system="Amarr",
+            alert_system="HED-GP",
+            jump_calculator=calc,
+            max_jumps=2,
+        )
+        assert should is True
+        # 0.5 ** 1 = 0.5 (above floor 0.4)
+        assert alpha == 0.5
+
+    def test_two_jumps_within_threshold_uses_floor_alpha(self):
+        calc = MagicMock()
+        calc.distance.return_value = 2
+        should, alpha = resolve_tint(
+            known_system="Amarr",
+            alert_system="HED-GP",
+            jump_calculator=calc,
+            max_jumps=2,
+        )
+        assert should is True
+        # 0.5 ** 2 = 0.25 → clamped to 0.4 floor
+        assert alpha == 0.4
+
+    def test_distance_beyond_threshold_skipped(self):
+        calc = MagicMock()
+        calc.distance.return_value = 3
+        should, alpha = resolve_tint(
+            known_system="Amarr",
+            alert_system="HED-GP",
+            jump_calculator=calc,
+            max_jumps=2,
+        )
+        assert should is False
+        assert alpha == 0.0
+
+    def test_unknown_distance_skipped(self):
+        """JumpCalculator returns None when graph lookup fails."""
+        calc = MagicMock()
+        calc.distance.return_value = None
+        should, alpha = resolve_tint(
+            known_system="Unknown",
+            alert_system="HED-GP",
+            jump_calculator=calc,
+            max_jumps=5,
+        )
+        assert should is False
+        assert alpha == 0.0


### PR DESCRIPTION
> **Stacked on #66 → #65 → #64 → #63 → #62.** Merge order: 62 → 63 → 64 → 65 → 66 → this. Auto-retargeting handles the chain.

## Summary
PR #66's smart fan-out only tinted exact-system matches. Real fleet awareness needs adjacency: a hostile one jump from your character is still meaningful. This PR adds \`JumpCalculator\` integration and a per-jump alpha falloff so adjacent-system alerts tint at reduced intensity instead of being silently skipped.

## Algorithm — \`intel/threat_filter.resolve_tint\`
| Case | should_apply | alpha |
|---|---|---|
| Same system | True | 1.0 |
| Unknown char location OR no alert system | True | 1.0 (graceful fallback) |
| Distance ≤ max_jumps | True | \`max(0.4, 0.5 ** distance)\` |
| Distance > max_jumps OR unknown | False | 0.0 |
| No calculator OR max_jumps=0 | False | 0.0 (PR5 behavior) |

So 0 jumps = 1.0, 1 jump = 0.5, 2+ jumps = 0.4 floor.

## What's new
- **\`intel/threat_filter.py\`** — single source of filter truth. Used by both \`WindowManager\` and \`StatusDock\` so rules can't drift between preview grid and chip strip
- **\`WindowPreviewWidget.set_threat_state\`** gains \`initial_alpha=1.0\` param. Pulse animation gates on \`initial_alpha >= 0.9\` so distant alerts glow but don't pulse
- **\`WindowManager.set_jump_calculator(calc, max_jumps=1)\`** + same on \`StatusDock\`
- **\`MainWindowV21._init_threat_jump_filter\`** constructs one shared \`JumpCalculator\` and injects it into both. Gated on \`intel.threat_jumps_threshold\` (default 1)

## The composite UX
> "hostiles HED-GP +3" fires → character in HED-GP pulses **red at full intensity** → characters one jump away tint **orange at half intensity** but don't pulse → distant characters stay calm.

This is the kind of ambient awareness EVE-O Preview cannot offer at any tier.

## Test plan
- [x] 25 new tests
  - 11 \`TestResolveTintExplicitFlush\` / \`TestResolveTintExactMatch\` / \`TestResolveTintAdjacency\` (helper)
  - 5 \`TestWindowPreviewWidgetInitialAlpha\` (widget kwarg + pulse gating)
  - 5 \`TestWindowManagerJumpsFromFanout\` (manager integration with mocked calculator)
  - 4 \`TestStatusDockJumpsFromFanout\` (dock integration with mocked calculator)
- [x] 2 existing fan-out assertions updated for the new \`initial_alpha=1.0\` kwarg (backward compat preserved otherwise)
- [x] Full suite: **2331 passed, 5 skipped, 0 failures**
- [x] \`ruff check\` + \`ruff format --check\` clean

## Settings
- \`intel.threat_jumps_threshold\` — default 1. Set to 0 to disable adjacency tinting (exact-match only). Set higher (2-3) for more aggressive ambient awareness.

## Follow-ups (future PRs)
- **Per-character accent border**: frame border inherits chip accent when threat is clear (identification at small sizes)
- **Workspace minimap**: bird's-eye dot map of dock+grid in a corner
- **Distance label on chip**: show "+1j" badge when chip is tinted at adjacent intensity

🤖 Generated with [Claude Code](https://claude.com/claude-code)