### PR TITLE
feat(ui): "+Nj" distance badge on adjacent-tinted chips

### DIFF
--- a/src/argus_overview/intel/threat_filter.py
+++ b/src/argus_overview/intel/threat_filter.py
@@ -66,7 +66,11 @@ def resolve_tint(
     if jump_calculator is None or max_jumps <= 0:
         return False, 0.0
 
-    distance = jump_calculator.distance(known_system, alert_system)
+    try:
+        distance = jump_calculator.distance(known_system, alert_system)
+    except (AttributeError, TypeError, ValueError):
+        # Calculator misconfigured / corrupt — treat as unknown distance.
+        return False, 0.0
     if distance is None or distance > max_jumps:
         return False, 0.0
 

--- a/src/argus_overview/ui/status_dock.py
+++ b/src/argus_overview/ui/status_dock.py
@@ -84,6 +84,9 @@ class CharacterChip(QFrame):
         self._system: str | None = None
         self._threat_level: ThreatLevel | None = None
         self._threat_alpha: float = 0.0
+        # PR7: jumps from this chip's character to the alert system. None when
+        # same-system or unknown; positive int for adjacent. Renders as +Nj.
+        self._threat_distance: int | None = None
 
         self.setFixedHeight(40)
         self.setMinimumWidth(160)
@@ -157,7 +160,10 @@ class CharacterChip(QFrame):
         if self._system:
             parts.append(f"System: {self._system}")
         if self._threat_level is not None:
-            parts.append(f"Threat: {self._threat_level.value}")
+            line = f"Threat: {self._threat_level.value}"
+            if self._threat_distance and self._threat_distance > 0:
+                line += f" ({self._threat_distance}j away)"
+            parts.append(line)
         parts.append("Click to focus window")
         return "\n".join(parts)
 
@@ -168,14 +174,32 @@ class CharacterChip(QFrame):
         self.setToolTip(self._tooltip_text())
 
     def set_threat_state(
-        self, level: ThreatLevel | None, system: str | None = None, alpha: float = 1.0
+        self,
+        level: ThreatLevel | None,
+        system: str | None = None,
+        alpha: float = 1.0,
+        distance: int | None = None,
     ) -> None:
+        """
+        Update threat state for this chip.
+
+        Args:
+            level: Threat level. None or CLEAR clears state.
+            system: System the alert refers to.
+            alpha: Initial alpha [0, 1] for the threat dot. PR6 falloff for
+                adjacent-system alerts uses < 1.0.
+            distance: Jumps from this chip's character to the alert system.
+                None for same-system or unknown. Positive ints render as
+                "+Nj" badge next to the threat dot (PR7).
+        """
         if level is None or level == ThreatLevel.CLEAR:
             self._threat_level = None
             self._threat_alpha = 0.0
+            self._threat_distance = None
         else:
             self._threat_level = level
             self._threat_alpha = max(0.0, min(1.0, alpha))
+            self._threat_distance = distance if distance and distance > 0 else None
         if system is not None:
             self.set_system(system)
         else:
@@ -204,9 +228,31 @@ class CharacterChip(QFrame):
             painter.setPen(QPen(color.darker(140), 1))
             painter.setBrush(QBrush(color))
             # Draw threat dot vertically centered, left of the right edge
-            x = self.width() - self.DOT_SIZE - 8
-            y = (self.height() - self.DOT_SIZE) // 2
-            painter.drawEllipse(x, y, self.DOT_SIZE, self.DOT_SIZE)
+            dot_x = self.width() - self.DOT_SIZE - 8
+            dot_y = (self.height() - self.DOT_SIZE) // 2
+            painter.drawEllipse(dot_x, dot_y, self.DOT_SIZE, self.DOT_SIZE)
+
+            # PR7: distance badge for adjacent-system alerts.
+            # Renders as "+Nj" just left of the threat dot in the same color.
+            if self._threat_distance and self._threat_distance > 0:
+                from PySide6.QtGui import QFont
+
+                badge_text = f"+{self._threat_distance}j"
+                font = painter.font()
+                badge_font = QFont(font)
+                badge_font.setPointSize(7)
+                badge_font.setBold(True)
+                painter.setFont(badge_font)
+                # Foreground stays in the threat color but bumped opaque so
+                # it stays legible even when the dot itself is dim.
+                text_color = QColor(r, g, b, max(180, alpha))
+                painter.setPen(QPen(text_color))
+                metrics = painter.fontMetrics()
+                text_w = metrics.horizontalAdvance(badge_text)
+                # Place to the left of the dot, vertically centered.
+                text_x = dot_x - text_w - 3
+                text_y = (self.height() + metrics.ascent() - metrics.descent()) // 2
+                painter.drawText(text_x, text_y, badge_text)
         finally:
             painter.end()
 
@@ -328,7 +374,19 @@ class StatusDock(QWidget):
                 )
                 if not should_apply:
                     continue
-                chip.set_threat_state(level, system, alpha=alpha)
+                # PR7: surface the jump distance for the +Nj badge.
+                distance: int | None = None
+                if (
+                    alpha < 1.0
+                    and chip_system
+                    and calculator is not None
+                    and chip_system.lower() != system.lower()
+                ):
+                    try:
+                        distance = calculator.distance(chip_system, system)
+                    except (AttributeError, TypeError, ValueError):
+                        distance = None
+                chip.set_threat_state(level, system, alpha=alpha, distance=distance)
                 count += 1
             except RuntimeError:
                 continue

--- a/tests/test_status_dock.py
+++ b/tests/test_status_dock.py
@@ -405,3 +405,161 @@ class TestMainWindowV21StatusDockFanout:
         # Should not raise even though main_tab has no status_dock attr
         window._on_intel_alert(report, AlertType.VISUAL_BORDER)
         window.main_tab.window_manager.apply_threat_state.assert_called_once()
+
+
+# =============================================================================
+# Distance badge (PR7)
+# =============================================================================
+
+
+class TestCharacterChipDistanceBadge:
+    """+Nj badge state on the chip."""
+
+    def test_default_distance_is_none(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            assert chip._threat_distance is None
+        finally:
+            chip.deleteLater()
+
+    def test_distance_stored_when_positive(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_threat_state(ThreatLevel.WARNING, "HED-GP", alpha=0.5, distance=2)
+            assert chip._threat_distance == 2
+        finally:
+            chip.deleteLater()
+
+    def test_zero_distance_treated_as_none(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            # Same-system case: caller passes distance=0; chip stores None
+            chip.set_threat_state(ThreatLevel.DANGER, "HED-GP", alpha=1.0, distance=0)
+            assert chip._threat_distance is None
+        finally:
+            chip.deleteLater()
+
+    def test_clear_resets_distance(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_threat_state(ThreatLevel.WARNING, "HED-GP", alpha=0.5, distance=2)
+            chip.set_threat_state(ThreatLevel.CLEAR)
+            assert chip._threat_distance is None
+        finally:
+            chip.deleteLater()
+
+    def test_paint_with_distance_does_not_crash(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.resize(200, 40)
+            chip.set_threat_state(ThreatLevel.WARNING, "HED-GP", alpha=0.5, distance=1)
+            chip.repaint()
+        finally:
+            chip.deleteLater()
+
+    def test_paint_with_no_distance_does_not_crash(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.resize(200, 40)
+            chip.set_threat_state(ThreatLevel.DANGER, "HED-GP", alpha=1.0)
+            chip.repaint()
+        finally:
+            chip.deleteLater()
+
+    def test_tooltip_includes_distance(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_system("Jita")
+            chip.set_threat_state(ThreatLevel.WARNING, "HED-GP", alpha=0.5, distance=2)
+            tip = chip.toolTip()
+            assert "2j away" in tip
+        finally:
+            chip.deleteLater()
+
+    def test_tooltip_omits_distance_for_same_system(self, qapp):
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            chip.set_system("HED-GP")
+            chip.set_threat_state(ThreatLevel.DANGER, "HED-GP", alpha=1.0)
+            tip = chip.toolTip()
+            assert "j away" not in tip
+        finally:
+            chip.deleteLater()
+
+
+class TestStatusDockPassesDistanceToChip:
+    """Dock fan-out queries calculator.distance and passes it to chips."""
+
+    def _make_calc(self, distance: int | None):
+        calc = MagicMock()
+        calc.distance.return_value = distance
+        return calc
+
+    def test_adjacent_chip_receives_distance(self, qapp):
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.set_jump_calculator(self._make_calc(distance=1), max_jumps=2)
+            dock.add_chip("0x1", "Alice")
+            dock.set_character_system("Alice", "Jita")
+
+            dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+            assert dock._chips["0x1"]._threat_distance == 1
+        finally:
+            dock.deleteLater()
+
+    def test_same_system_chip_has_no_distance(self, qapp):
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.set_jump_calculator(self._make_calc(distance=0), max_jumps=2)
+            dock.add_chip("0x1", "Alice")
+            dock.set_character_system("Alice", "HED-GP")
+
+            dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+            assert dock._chips["0x1"]._threat_distance is None
+        finally:
+            dock.deleteLater()
+
+    def test_unknown_chip_system_has_no_distance(self, qapp):
+        """Graceful fallback: unknown chip tints at full alpha, no badge."""
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            dock.set_jump_calculator(self._make_calc(distance=99), max_jumps=2)
+            dock.add_chip("0x1", "Alice")
+            # No set_character_system → chip._system stays None
+
+            dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+            assert dock._chips["0x1"]._threat_distance is None
+            # Calculator should not have been queried at all (alpha=1.0 path)
+        finally:
+            dock.deleteLater()
+
+    def test_calculator_error_swallowed(self, qapp):
+        from argus_overview.ui.status_dock import StatusDock
+
+        dock = StatusDock()
+        try:
+            calc = MagicMock()
+            calc.distance.side_effect = ValueError("graph corrupt")
+            dock.set_jump_calculator(calc, max_jumps=2)
+            dock.add_chip("0x1", "Alice")
+            dock.set_character_system("Alice", "Jita")
+
+            # Force smart-filter branch by stubbing resolve_tint? No — just
+            # rely on real resolve_tint: it would call calculator.distance
+            # too. Either way, the dock should not raise.
+            dock.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+            # Chip threat state may or may not be set depending on which
+            # call raised, but the dock must not have crashed.
+            assert "0x1" in dock._chips
+        finally:
+            dock.deleteLater()


### PR DESCRIPTION
> **Stacked on #67 → #66 → #65 → #64 → #63 → #62.** Merge order: 62 → 63 → 64 → 65 → 66 → 67 → this.

## Summary
Closes the UX loop on PR #67's adjacency tinting. Before this PR, a chip dimmed at 50% red gave you no signal about **why** it was dim — was the alert weak, or was the character far from it? Now adjacent-system alerts paint a **\"+Nj\"** badge in the threat color next to the dot, and the tooltip explicitly says \"warning (1j away)\".

## What changes
- \`CharacterChip._threat_distance: int | None\` — set by the dock during smart fan-out, drawn in \`paintEvent\` as bold 7pt text just left of the threat dot. Zero or None → no badge (same-system)
- \`CharacterChip.set_threat_state\` gains \`distance\` kwarg. Tooltip appends \`(Nj away)\` when distance > 0
- \`StatusDock.set_threat_state\` queries \`jump_calculator.distance\` for chips whose alpha came back < 1.0 from \`resolve_tint\`, then passes the value through to the chip. Errors swallowed (calculator misconfig shouldn't crash the alert path)
- \`intel/threat_filter.resolve_tint\` hardened: swallows \`AttributeError\` / \`TypeError\` / \`ValueError\` from \`calculator.distance\` and returns \`(False, 0.0)\`

## Visual
| State | Dot | Badge | Tooltip |
|---|---|---|---|
| Same system, danger | full red | — | \"Threat: danger\" |
| 1 jump away, danger | half-opacity red | **+1j** in red | \"Threat: danger (1j away)\" |
| 2 jumps away, warning | dim orange | **+2j** in orange | \"Threat: warning (2j away)\" |

## Test plan
- [x] 12 new tests
  - \`TestCharacterChipDistanceBadge\`: state defaults, positive distance stored, zero treated as None, clear resets, paint smoke (with + without distance), tooltip with + without distance
  - \`TestStatusDockPassesDistanceToChip\`: adjacent chip receives distance, same-system has none, unknown chip-system has none (alpha=1.0 path skips calculator entirely), calculator error swallowed
- [x] Full suite: **2343 passed, 5 skipped, 0 failures**
- [x] \`ruff check\` + \`ruff format --check\` clean

## Follow-ups
- Same badge on the preview frame chrome (currently chip-only)
- Per-character accent border on frames when threat is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)