### PR TITLE
feat(ui): per-character accent border on preview frames

### DIFF
--- a/src/argus_overview/ui/main_tab.py
+++ b/src/argus_overview/ui/main_tab.py
@@ -73,6 +73,32 @@ THREAT_DECAY_DURATION_MS = 30_000  # full fade time after last alert
 THREAT_PULSE_TICK_MS = 33  # ~30 fps pulse
 THREAT_PULSE_DURATION_MS = 600  # one pulse cycle
 
+# Per-character accent palette (PR8). Shared by both frames + chips so
+# the same character renders in the same color across the preview grid
+# and the status dock. Palette is fixed-length; deterministic hash maps
+# names to indices.
+CHARACTER_ACCENT_COLORS: list[tuple[int, int, int]] = [
+    (255, 100, 100),
+    (100, 255, 100),
+    (100, 150, 255),
+    (255, 200, 80),
+    (220, 120, 220),
+    (100, 220, 220),
+    (255, 165, 60),
+    (170, 130, 255),
+]
+
+
+def character_accent_color(name: str) -> QColor:
+    """Deterministic accent color for a character name.
+
+    Used by both WindowPreviewWidget (frame border) and CharacterChip
+    (avatar fill) so visual identity is consistent across surfaces.
+    """
+    r, g, b = CHARACTER_ACCENT_COLORS[abs(hash(name)) % len(CHARACTER_ACCENT_COLORS)]
+    return QColor(r, g, b)
+
+
 # Module-level constant: avoids re-creating the dict on every pil_to_qimage call
 _FORMAT_MAP = {
     "RGB": (3, QImage.Format.Format_RGB888),
@@ -633,6 +659,9 @@ class WindowPreviewWidget(QWidget):
         # WindowManager.apply_threat_state for smart fan-out.
         self._character_system: str | None = None
 
+        # PR8: per-character accent color, shared with the chip.
+        self._accent_color: QColor = character_accent_color(character_name)
+
         # Intel threat state (PR1: intel-aware preview borders)
         self._threat_level: ThreatLevel | None = None
         self._threat_system: str | None = None
@@ -983,11 +1012,25 @@ class WindowPreviewWidget(QWidget):
         self.update()
 
     def paintEvent(self, event):
-        """Custom paint: threat border, focus dot, lock icon, legacy flash."""
+        """Custom paint: accent, threat border, focus dot, lock icon, flash."""
         super().paintEvent(event)
 
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        # 0. Per-character accent border (PR8) — only visible when no
+        # threat or legacy-flash overlay is active. Gives instant visual
+        # identity at small grid sizes and matches the chip avatar color.
+        if (
+            self._threat_level is None
+            and self._flash_color is None
+            and getattr(self, "_accent_color", None) is not None
+        ):
+            pen = QPen(self._accent_color)
+            pen.setWidth(2)
+            painter.setPen(pen)
+            painter.setBrush(QBrush(Qt.BrushStyle.NoBrush))
+            painter.drawRoundedRect(2, 2, self.width() - 4, self.height() - 4, 4, 4)
 
         # 1. Threat-tint border (PR1) — drawn first so dot/lock paint over it
         if self._threat_level is not None and self._threat_alpha > 0.0:

--- a/src/argus_overview/ui/status_dock.py
+++ b/src/argus_overview/ui/status_dock.py
@@ -28,25 +28,16 @@ from PySide6.QtWidgets import (
 )
 
 from argus_overview.intel.parser import ThreatLevel
-from argus_overview.ui.main_tab import THREAT_BORDER_COLORS
+from argus_overview.ui.main_tab import (
+    CHARACTER_ACCENT_COLORS,
+    THREAT_BORDER_COLORS,
+    character_accent_color,
+)
 
-# Stable accent palette — same hue per character across sessions
-CHIP_ACCENT_COLORS: list[tuple[int, int, int]] = [
-    (255, 100, 100),
-    (100, 255, 100),
-    (100, 150, 255),
-    (255, 200, 80),
-    (220, 120, 220),
-    (100, 220, 220),
-    (255, 165, 60),
-    (170, 130, 255),
-]
-
-
-def accent_for(name: str) -> QColor:
-    """Deterministic accent color for a character name."""
-    r, g, b = CHIP_ACCENT_COLORS[abs(hash(name)) % len(CHIP_ACCENT_COLORS)]
-    return QColor(r, g, b)
+# Backward-compatible aliases — PR8 promoted these to main_tab.py so
+# frames + chips share one palette + helper. Public names preserved.
+CHIP_ACCENT_COLORS = CHARACTER_ACCENT_COLORS
+accent_for = character_accent_color
 
 
 def _initials(name: str) -> str:

--- a/tests/test_main_tab.py
+++ b/tests/test_main_tab.py
@@ -10199,3 +10199,110 @@ class TestStatusDockJumpsFromFanout:
             assert dock._chips["0x1"]._threat_level is None
         finally:
             dock.deleteLater()
+
+
+# =============================================================================
+# Per-character accent border (PR8)
+# =============================================================================
+
+
+class TestCharacterAccentColor:
+    """Shared accent palette helper used by frames + chips."""
+
+    def test_deterministic(self):
+        from argus_overview.ui.main_tab import character_accent_color
+
+        assert character_accent_color("Pilot1").rgb() == character_accent_color("Pilot1").rgb()
+
+    def test_returns_qcolor(self):
+        from PySide6.QtGui import QColor
+
+        from argus_overview.ui.main_tab import character_accent_color
+
+        assert isinstance(character_accent_color("X"), QColor)
+
+    def test_palette_has_eight_entries(self):
+        from argus_overview.ui.main_tab import CHARACTER_ACCENT_COLORS
+
+        assert len(CHARACTER_ACCENT_COLORS) == 8
+
+
+class TestCharacterAccentChipFrameMatch:
+    """Same character → same color across the frame and the chip."""
+
+    def test_frame_and_chip_share_accent(self, qapp):
+        from argus_overview.ui.main_tab import WindowPreviewWidget
+        from argus_overview.ui.status_dock import CharacterChip
+
+        widget = WindowPreviewWidget(
+            window_id="0xABC",
+            character_name="TestPilot",
+            capture_system=MagicMock(),
+        )
+        chip = CharacterChip("0xABC", "TestPilot")
+        try:
+            assert widget._accent_color.rgb() == chip._accent.rgb()
+        finally:
+            widget.deleteLater()
+            chip.deleteLater()
+
+    def test_legacy_chip_aliases_resolve_to_main_tab_helpers(self):
+        from argus_overview.ui.main_tab import (
+            CHARACTER_ACCENT_COLORS,
+            character_accent_color,
+        )
+        from argus_overview.ui.status_dock import CHIP_ACCENT_COLORS, accent_for
+
+        assert CHIP_ACCENT_COLORS is CHARACTER_ACCENT_COLORS
+        assert accent_for is character_accent_color
+
+
+class TestWindowPreviewAccentBorder:
+    """Frame paints the accent border only when no threat is active."""
+
+    def _make_widget(self, qapp):
+        from argus_overview.ui.main_tab import WindowPreviewWidget
+
+        return WindowPreviewWidget(
+            window_id="0xABC",
+            character_name="TestPilot",
+            capture_system=MagicMock(),
+        )
+
+    def test_accent_color_set_on_init(self, qapp):
+        from PySide6.QtGui import QColor
+
+        widget = self._make_widget(qapp)
+        try:
+            assert isinstance(widget._accent_color, QColor)
+        finally:
+            widget.deleteLater()
+
+    def test_paint_clear_state_does_not_crash(self, qapp):
+        widget = self._make_widget(qapp)
+        try:
+            widget.resize(200, 150)
+            # No threat, no flash → accent border should paint
+            widget.repaint()
+        finally:
+            widget.deleteLater()
+
+    def test_paint_with_threat_does_not_crash(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.resize(200, 150)
+            widget.set_threat_state(ThreatLevel.DANGER, "HED-GP")
+            widget.repaint()
+        finally:
+            widget.deleteLater()
+
+    def test_paint_with_flash_does_not_crash(self, qapp):
+        widget = self._make_widget(qapp)
+        try:
+            widget.resize(200, 150)
+            widget.flash_border("#FF0000", 1000)
+            widget.repaint()
+        finally:
+            widget.deleteLater()


### PR DESCRIPTION
> **Stacked on #68 → #67 → ... → #62.** Merge order: 62 → 63 → 64 → 65 → 66 → 67 → 68 → this.

## Summary
Frames now paint a 2px accent border in the same color as the character's chip avatar. Visible only when no threat tint is active — threat overdraws it during alerts. At small grid sizes (12+ multiboxed clients) the accent makes it instant to identify which client a frame belongs to without reading the name label.

## What changes
- **\`main_tab.py\`**: promoted \`CHIP_ACCENT_COLORS\` + \`accent_for\` from \`status_dock\` into \`CHARACTER_ACCENT_COLORS\` + \`character_accent_color\`. Both surfaces now share one palette so frame border and chip avatar always match for the same character
- **\`WindowPreviewWidget._accent_color\`** set on init from \`character_name\`. \`paintEvent\` draws the 2px rounded accent rect when \`threat_level is None\` and \`flash_color is None\`. When threat fires, the threat border (3-5px) overdraws
- **\`status_dock.py\`**: keeps \`CHIP_ACCENT_COLORS\` / \`accent_for\` as backward-compatible aliases pointing at the main_tab helpers. No public-API break

## Why it matters
Across the seven prior PRs, the dock and the frames diverged in visual identity: the chip showed a colored avatar but the frame had no character-specific signal in its chrome. With 8+ EVE clients at small grid sizes, name labels become unreadable and the activity dot is just on/off. The accent border closes that gap — character identity is now glanceable in the chrome itself.

## Visual layering (paint order, top to bottom)
1. **Accent border** (2px, this PR) — only when clear
2. **Threat border** (3-5px) — covers accent when threat fires
3. **Legacy flash overlay** (3px)
4. **Activity dot** (focus indicator, top-right)
5. **Lock icon** (top-left)

## Test plan
- [x] 9 new tests
  - \`TestCharacterAccentColor\` (3): deterministic, QColor type, 8-entry palette
  - \`TestCharacterAccentChipFrameMatch\` (2): same color across frame + chip; legacy aliases resolve to new home
  - \`TestWindowPreviewAccentBorder\` (4): init state, paint smoke for clear / threat / flash branches
- [x] Full suite: **2352 passed, 5 skipped, 0 failures**
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] All existing PR3 \`test_status_dock.py\` accent tests still pass via backward-compat aliases

## Follow-ups
- Distance badge on preview frames (symmetrize PR #68 across grid + dock)
- Workspace minimap

🤖 Generated with [Claude Code](https://claude.com/claude-code)