### PR TITLE
feat(ui): "+Nj" distance badge on preview frames

### DIFF
--- a/src/argus_overview/ui/main_tab.py
+++ b/src/argus_overview/ui/main_tab.py
@@ -665,6 +665,10 @@ class WindowPreviewWidget(QWidget):
         # Intel threat state (PR1: intel-aware preview borders)
         self._threat_level: ThreatLevel | None = None
         self._threat_system: str | None = None
+        # PR9: jumps from this character to the alert system. None for
+        # same-system / unknown; positive int renders as "+Nj" near the
+        # top-left of the threat border.
+        self._threat_distance: int | None = None
         # Decay alpha drives the inset border; ranges 0.0 (off) to 1.0 (full)
         self._threat_alpha: float = 0.0
         self._threat_decay_steps: int = max(1, THREAT_DECAY_DURATION_MS // THREAT_DECAY_TICK_MS)
@@ -900,6 +904,7 @@ class WindowPreviewWidget(QWidget):
         level: ThreatLevel | None,
         system: str | None = None,
         initial_alpha: float = 1.0,
+        distance: int | None = None,
     ) -> None:
         """
         Update the intel threat state for this preview frame.
@@ -911,6 +916,9 @@ class WindowPreviewWidget(QWidget):
                 to 1.0 (full intensity for same-system alerts). Lower values
                 are used by WindowManager when fanning to characters in
                 adjacent systems via the jumps-from filter (PR6).
+            distance: Jumps from this character to the alert system.
+                None for same-system / unknown. Positive ints render as a
+                "+Nj" badge near the top-left of the frame (PR9).
         """
         prev_level = self._threat_level
 
@@ -918,6 +926,7 @@ class WindowPreviewWidget(QWidget):
             self._threat_level = None
             self._threat_system = None
             self._threat_alpha = 0.0
+            self._threat_distance = None
             self._threat_decay_timer.stop()
             self.update()
             return
@@ -925,6 +934,7 @@ class WindowPreviewWidget(QWidget):
         self._threat_level = level
         self._threat_system = system
         self._threat_alpha = max(0.0, min(1.0, initial_alpha))
+        self._threat_distance = distance if distance and distance > 0 else None
 
         # Pulse on upgrade into danger/critical (only at full-ish intensity —
         # don't pulse for distant adjacent-system alerts).
@@ -951,6 +961,7 @@ class WindowPreviewWidget(QWidget):
         if self._threat_alpha <= 0.0:
             self._threat_level = None
             self._threat_system = None
+            self._threat_distance = None
             self._threat_decay_timer.stop()
         self.update()
 
@@ -1054,6 +1065,25 @@ class WindowPreviewWidget(QWidget):
                 4,
                 4,
             )
+
+            # PR9: distance badge — "+Nj" near the top-left corner inside
+            # the threat border, in the threat color. Only renders for
+            # adjacent-system alerts (distance > 0).
+            if self._threat_distance and self._threat_distance > 0:
+                from PySide6.QtGui import QFont
+
+                badge_text = f"+{self._threat_distance}j"
+                badge_font = QFont(painter.font())
+                badge_font.setPointSize(8)
+                badge_font.setBold(True)
+                painter.setFont(badge_font)
+                # Foreground stays in the threat color, opaque so it's
+                # legible even when the border itself is dim.
+                text_color = QColor(r, g, b, max(200, alpha))
+                painter.setPen(QPen(text_color))
+                # Shifted right of where the lock icon sits (x=6) so they
+                # don't overlap when both are visible.
+                painter.drawText(28, 18, badge_text)
 
         # 2. Legacy flash overlay (compat with border_flash_requested)
         if self._flash_color is not None:
@@ -1382,7 +1412,20 @@ class WindowManager:
                 )
                 if not should_apply:
                     continue
-                frame.set_threat_state(level, system, initial_alpha=alpha)
+                # PR9: surface the jump distance for the +Nj frame badge.
+                # Mirrors StatusDock.set_threat_state behavior (PR7).
+                distance: int | None = None
+                if (
+                    alpha < 1.0
+                    and known
+                    and calculator is not None
+                    and known.lower() != system.lower()
+                ):
+                    try:
+                        distance = calculator.distance(known, system)
+                    except (AttributeError, TypeError, ValueError):
+                        distance = None
+                frame.set_threat_state(level, system, initial_alpha=alpha, distance=distance)
                 count += 1
             except RuntimeError:
                 continue

--- a/tests/test_main_tab.py
+++ b/tests/test_main_tab.py
@@ -9262,14 +9262,15 @@ class TestWindowManagerApplyThreatState:
             assert count == 3
             # PR6: smart-filter branch passes initial_alpha=1.0 explicitly when
             # the per-character system is unknown (graceful fallback).
+            # PR9: also passes distance=None for the +Nj badge surface.
             f1.set_threat_state.assert_called_once_with(
-                ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+                ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0, distance=None
             )
             f2.set_threat_state.assert_called_once_with(
-                ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+                ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0, distance=None
             )
             f3.set_threat_state.assert_called_once_with(
-                ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+                ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0, distance=None
             )
 
     def test_apply_threat_state_empty_frames(self):
@@ -9832,7 +9833,7 @@ class TestWindowManagerApplyThreatStateSmartFanout:
 
         assert count == 1
         alice.set_threat_state.assert_called_once_with(
-            ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0, distance=None
         )
         bob.set_threat_state.assert_not_called()
 
@@ -10090,10 +10091,10 @@ class TestWindowManagerJumpsFromFanout:
 
         assert count == 2
         bob.set_threat_state.assert_called_once_with(
-            ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0, distance=None
         )
         alice.set_threat_state.assert_called_once_with(
-            ThreatLevel.DANGER, "HED-GP", initial_alpha=0.5
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=0.5, distance=1
         )
 
     def test_beyond_threshold_skipped(self):
@@ -10306,3 +10307,167 @@ class TestWindowPreviewAccentBorder:
             widget.repaint()
         finally:
             widget.deleteLater()
+
+
+# =============================================================================
+# Frame distance badge (PR9 — symmetrize PR7 across grid + dock)
+# =============================================================================
+
+
+class TestWindowPreviewWidgetDistanceBadge:
+    def _make_widget(self, qapp):
+        from argus_overview.ui.main_tab import WindowPreviewWidget
+
+        return WindowPreviewWidget(
+            window_id="0xABC",
+            character_name="TestPilot",
+            capture_system=MagicMock(),
+        )
+
+    def test_default_distance_is_none(self, qapp):
+        widget = self._make_widget(qapp)
+        try:
+            assert widget._threat_distance is None
+        finally:
+            widget.deleteLater()
+
+    def test_distance_stored_when_positive(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.set_threat_state(ThreatLevel.WARNING, "HED-GP", initial_alpha=0.5, distance=2)
+            assert widget._threat_distance == 2
+        finally:
+            widget.deleteLater()
+
+    def test_zero_distance_treated_as_none(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.set_threat_state(ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0, distance=0)
+            assert widget._threat_distance is None
+        finally:
+            widget.deleteLater()
+
+    def test_clear_resets_distance(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.set_threat_state(ThreatLevel.WARNING, "HED-GP", initial_alpha=0.5, distance=2)
+            widget.set_threat_state(ThreatLevel.CLEAR)
+            assert widget._threat_distance is None
+        finally:
+            widget.deleteLater()
+
+    def test_decay_to_zero_clears_distance(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.set_threat_state(ThreatLevel.WARNING, "HED-GP", initial_alpha=0.5, distance=2)
+            # Tighten decay so a single tick fully drains.
+            widget._threat_decay_steps = 1
+            widget._threat_alpha = 0.5  # ensure > 0 so first branch runs
+            widget._tick_threat_decay()
+            assert widget._threat_distance is None
+            assert widget._threat_level is None
+        finally:
+            widget.deleteLater()
+
+    def test_paint_with_distance_does_not_crash(self, qapp):
+        from argus_overview.intel.parser import ThreatLevel
+
+        widget = self._make_widget(qapp)
+        try:
+            widget.resize(200, 150)
+            widget.set_threat_state(ThreatLevel.WARNING, "HED-GP", initial_alpha=0.5, distance=1)
+            widget.repaint()
+        finally:
+            widget.deleteLater()
+
+
+def _frame_mock_v2(character_name: str):
+    """Mock frame for WindowManager tests — preserves character_name."""
+    f = MagicMock()
+    f.character_name = character_name
+    return f
+
+
+class TestWindowManagerPassesDistanceToFrame:
+    def _make_calc(self, distance: int | None):
+        calc = MagicMock()
+        calc.distance.return_value = distance
+        return calc
+
+    def _make_manager(self, char_systems=None, max_jumps=0, calc=None):
+        from argus_overview.ui.main_tab import WindowManager
+
+        manager = WindowManager.__new__(WindowManager)
+        manager.preview_frames = {}
+        manager._character_systems = dict(char_systems or {})
+        manager._jump_calculator = calc
+        manager._jump_max = max_jumps
+        return manager
+
+    def test_adjacent_frame_receives_distance(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        calc = self._make_calc(distance=1)
+        manager = self._make_manager(char_systems={"Alice": "Jita"}, max_jumps=2, calc=calc)
+        alice = _frame_mock_v2("Alice")
+        manager.preview_frames = {"w1": alice}
+
+        manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        alice.set_threat_state.assert_called_once_with(
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=0.5, distance=1
+        )
+
+    def test_same_system_frame_distance_is_none(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        calc = self._make_calc(distance=0)
+        manager = self._make_manager(char_systems={"Alice": "HED-GP"}, max_jumps=2, calc=calc)
+        alice = _frame_mock_v2("Alice")
+        manager.preview_frames = {"w1": alice}
+
+        manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        alice.set_threat_state.assert_called_once_with(
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0, distance=None
+        )
+        calc.distance.assert_not_called()
+
+    def test_unknown_character_distance_is_none(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        calc = self._make_calc(distance=99)
+        manager = self._make_manager(char_systems={}, max_jumps=2, calc=calc)
+        anon = _frame_mock_v2("Bob")
+        manager.preview_frames = {"w1": anon}
+
+        manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        anon.set_threat_state.assert_called_once_with(
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=1.0, distance=None
+        )
+
+    def test_calculator_error_swallowed(self):
+        from argus_overview.intel.parser import ThreatLevel
+
+        calc = MagicMock()
+        # First call (inside resolve_tint) returns a usable distance, second
+        # call (PR9 explicit query for the badge) raises.
+        calc.distance.side_effect = [1, ValueError("graph corrupt")]
+        manager = self._make_manager(char_systems={"Alice": "Jita"}, max_jumps=2, calc=calc)
+        alice = _frame_mock_v2("Alice")
+        manager.preview_frames = {"w1": alice}
+
+        manager.apply_threat_state(ThreatLevel.DANGER, "HED-GP")
+
+        alice.set_threat_state.assert_called_once_with(
+            ThreatLevel.DANGER, "HED-GP", initial_alpha=0.5, distance=None
+        )


### PR DESCRIPTION
> **Stacked on #70 → ... → #62.** Merge order: 62 → 63 → 64 → 65 → 66 → 67 → 68 → 70 → this.

## Summary
Symmetrizes PR #68 across grid + dock. The chip strip already showed \"+Nj\" badges for adjacent-system alerts; now preview frames carry the same chrome. At a glance, a dim red border with \"+1j\" text reads as: \"this character is one jump from where the hostile is\".

## What changes
- **\`WindowPreviewWidget._threat_distance\`** — mirrors \`CharacterChip._threat_distance\` from PR #68
- **\`set_threat_state(level, system, initial_alpha=1.0, distance=None)\`** — kwarg matches chip API
- **paintEvent** draws \"+Nj\" in 8pt bold threat color near top-left of frame, just right of the lock icon. Only renders when threat is active and \`distance > 0\`
- **Decay path** clears distance alongside level/system when alpha hits zero
- **\`WindowManager.apply_threat_state\`** queries \`jump_calculator.distance\` for frames whose alpha came back < 1.0, then passes through. Mirrors PR #68's StatusDock behavior. Calculator errors swallowed

## Visual layering on the frame
1. Accent border (PR #70, clear state only)
2. Threat border (PR #1, replaces accent during alert)
3. **+Nj badge** (this PR, top-left when distance > 0) ← new
4. Legacy flash overlay
5. Activity dot, lock icon

## Test plan
- [x] 10 new tests
  - \`TestWindowPreviewWidgetDistanceBadge\` (6): default state, positive distance stored, zero treated as None, clear resets, decay clears, paint smoke
  - \`TestWindowManagerPassesDistanceToFrame\` (4): adjacent receives distance, same-system has none, unknown character has none, calculator error swallowed
- [x] 3 existing fan-out assertions updated for new \`distance=None\` kwarg (call shape changed from 3-arg to 4-arg)
- [x] Full suite: **2362 passed, 5 skipped, 0 failures**
- [x] \`ruff check\` + \`ruff format --check\` clean

## Follow-ups
- Workspace minimap (bird's-eye dock+grid in a corner)
- Hover-scrub film strip on frames (last N capture frames as a strip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)