### PR TITLE
ci: ignore CVE-2026-3219 (pip) until upstream patch ships

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,4 +22,8 @@ jobs:
           pip install -e ".[dev]"
           pip install pip-audit
       - name: Run pip-audit
-        run: pip-audit
+        # Ignore CVE-2026-3219 (pip itself) — no fix version available as
+        # of 2026-04-26. pip is the package manager, not a runtime dep, and
+        # the advisory has no upstream patch yet. Re-evaluate when a fix
+        # ships.
+        run: pip-audit --ignore-vuln CVE-2026-3219


### PR DESCRIPTION
## Summary
\`pip-audit\` flags \`pip 26.0.1\` as vulnerable but no fix version exists yet, which is currently blocking every PR's Dependency Audit job. pip is the package manager, not a runtime dependency — the CVE doesn't affect Argus runtime behavior. Adds \`--ignore-vuln CVE-2026-3219\` with a comment so we can re-evaluate when a fix lands.

This unblocks the 10-PR intel-aware UI chain (#62 → #72) which all share the same audit failure.

## Test plan
- [ ] Confirms Dependency Audit passes on this PR
- [ ] Once merged, the rebase-onto-main of #62 picks up the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)