### PR TITLE
chore: register replay-strip toggle in ActionRegistry

### DIFF
--- a/src/argus_overview/ui/action_registry.py
+++ b/src/argus_overview/ui/action_registry.py
@@ -677,6 +677,21 @@ class ActionRegistry:
             )
         )
 
+        # PR10 follow-up: replay-strip toggle. The label stays static
+        # ("Toggle replay strip") because ActionSpec doesn't model
+        # state-dependent labels — the dynamic label was the reason this
+        # action lived inline in contextMenuEvent before this PR.
+        self.register(
+            ActionSpec(
+                id="toggle_replay_strip",
+                label="Toggle Replay Strip",
+                scope=ActionScope.OBJECT,
+                primary_home=PrimaryHome.WINDOW_CONTEXT,
+                tooltip="Show/hide a strip of recent capture frames at the bottom of this preview",
+                handler_name="_toggle_replay_strip",
+            )
+        )
+
         # Character Context Menu
         self.register(
             ActionSpec(

--- a/src/argus_overview/ui/main_tab.py
+++ b/src/argus_overview/ui/main_tab.py
@@ -1284,12 +1284,15 @@ class WindowPreviewWidget(QWidget):
         # Build context menu from ActionRegistry
         context_builder = ContextMenuBuilder()
 
-        # Handler map for context actions
+        # Handler map for context actions. toggle_replay_strip was added
+        # to the registry as a tier-3 WINDOW_CONTEXT action; it joins the
+        # other handlers here.
         handlers = {
             "focus_window": lambda: self.window_activated.emit(self.window_id),
             "minimize_window": self._minimize_window,
             "close_window": self._close_window,
             "set_label": self._show_label_dialog,
+            "toggle_replay_strip": self._toggle_replay_strip,
             "remove_from_preview": lambda: self.window_removed.emit(self.window_id),
         }
 
@@ -1299,17 +1302,6 @@ class WindowPreviewWidget(QWidget):
             current_zoom=self.zoom_factor,
             parent=self,
         )
-
-        # PR10: replay-strip toggle. Added directly here rather than via
-        # ActionRegistry because the action is per-widget state, not a
-        # global tier-1 / tier-2 action — registering it as a tier-3
-        # CONTEXT action would force a registry refactor for one toggle.
-        menu.addSeparator()
-        replay_label = (
-            "Hide replay strip" if self.is_replay_strip_enabled() else "Show replay strip"
-        )
-        replay_action = menu.addAction(replay_label)
-        replay_action.triggered.connect(self._toggle_replay_strip)
 
         menu.exec(event.globalPos())
 

--- a/src/argus_overview/ui/menu_builder.py
+++ b/src/argus_overview/ui/menu_builder.py
@@ -349,6 +349,8 @@ class ContextMenuBuilder:
             None,
             "zoom",
             None,
+            "toggle_replay_strip",
+            None,
             "remove_from_preview",
         ]
 

--- a/tests/test_action_registry.py
+++ b/tests/test_action_registry.py
@@ -584,6 +584,15 @@ class TestRegistryActionCoverage:
         assert action.scope == ActionScope.OBJECT
         assert action.primary_home == PrimaryHome.WINDOW_CONTEXT
 
+    def test_toggle_replay_strip_action_exists(self):
+        """toggle_replay_strip context action should exist (PR10 follow-up)"""
+        registry = ActionRegistry.get_instance()
+        action = registry.get("toggle_replay_strip")
+        assert action is not None
+        assert action.scope == ActionScope.OBJECT
+        assert action.primary_home == PrimaryHome.WINDOW_CONTEXT
+        assert action.handler_name == "_toggle_replay_strip"
+
     def test_lock_positions_is_checkable(self):
         """lock_positions should be checkable"""
         registry = ActionRegistry.get_instance()


### PR DESCRIPTION
## Summary
Closes the CLAUDE.md deviation I flagged in #72 (\"Do NOT create ad-hoc menus — use ActionRegistry for all UI actions\"). The replay-strip toggle now lives as a proper tier-3 \`WINDOW_CONTEXT\` action in the registry instead of being hand-wired in \`WindowPreviewWidget.contextMenuEvent\`.

## Trade-off
The dynamic label (\"Show replay strip\" / \"Hide replay strip\" based on state) collapses to one static label **\"Toggle Replay Strip\"**. \`ActionSpec\` doesn't model state-dependent labels, and the dynamic label was the only reason the action lived inline in #72.

The static label is a small UX regression for a much cleaner API:
- Every preview-frame action is sourced from one registry
- \`python -m argus_overview.ui.action_registry\` audit now covers it
- Future tooling walking the registry sees this action automatically
- No more ad-hoc menus

## Changes
- **\`action_registry.py\`**: register \`toggle_replay_strip\` ActionSpec
- **\`menu_builder.py\`**: insert in \`build_window_context_menu\` action_order between zoom and remove_from_preview, separated by a divider
- **\`main_tab.py\`**: drop the inline \`menu.addAction(...)\` block, add \`toggle_replay_strip\` to the handler dict
- **\`test_action_registry.py\`**: registry-aware test for the new action

## Test plan
- [x] Audit passes: \`python -m argus_overview.ui.action_registry\` → \`AUDIT RESULT: PASSED\`
- [x] Suite: 2392 passed, 5 skipped, 0 failures
- [x] \`ruff check\` + \`ruff format --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)