### PR TITLE
chore: add v3.2.0 release entry to Flatpak metainfo

### DIFF
--- a/flatpak/io.github.aretedriver.ArgusOverview.metainfo.xml
+++ b/flatpak/io.github.aretedriver.ArgusOverview.metainfo.xml
@@ -54,6 +54,21 @@
   </branding>
 
   <releases>
+    <release version="3.2.0" date="2026-04-26">
+      <description>
+        <p>Intel-Aware Edition — preview chrome now carries threat state from the chat-log parser.</p>
+        <ul>
+          <li>Threat-tint borders on previews with 30s decay and pulse on danger</li>
+          <li>Character status dock — chip strip with avatar, system, and threat dot</li>
+          <li>Preview focus mode — double-click to spotlight, Esc to exit</li>
+          <li>Per-character system tracking from EVE Local channel logs</li>
+          <li>Smart per-character + jumps-from threat fan-out</li>
+          <li>"+Nj" distance badges on chips and frames</li>
+          <li>Toggleable replay strip for combat scrubbing</li>
+          <li>Master toggle for users who prefer plain previews</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.1.2" date="2026-04-15">
       <description>
         <p>Security patch</p>


### PR DESCRIPTION
## Summary
The Flatpak metainfo.xml release list lagged behind by one entry — only 3.1.2 was the most recent. Adds 3.2.0 release notes so users browsing appstream metadata see the Intel-Aware Edition changelog.

This is debt item #3 from the post-v3.2.0 audit (\"sync remaining version refs\").

## Files NOT updated and why
The two yml manifests (\`io.github.aretedriver.ArgusOverview.yml\`, \`io.github.aretedriver.ArgusOverview.flathub.yml\`) still reference \`argus_overview-3.1.0-py3-none-any.whl\` with SHA256 hashes. Updating those requires:
1. Building a 3.2.0 wheel
2. Computing the SHA256
3. (For flathub.yml) publishing the wheel to PyPI

That's a **release-publish** task, not a version-sync task. Left for whoever ships 3.2.0 to PyPI/Flathub. Note that 3.1.0 is the version on PyPI today — the yml files were already stale through 3.1.1 and 3.1.2.

## Test plan
- [x] Full suite: 2398 passed, 5 skipped, 0 failures (no code change)
- [x] metainfo.xml is well-formed XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)