### PR TITLE
feat(ui): layouts tab pass 1 — visual pattern + monitor pickers

### DIFF
--- a/src/argus_overview/ui/layout_widgets.py
+++ b/src/argus_overview/ui/layout_widgets.py
@@ -1,0 +1,482 @@
+"""
+Layout-tab widgets: pattern thumbnails and monitor cards.
+
+The legacy Layouts tab uses a QComboBox of pattern names ("2x2 Grid",
+"Cascade", etc.) and a QSpinBox for monitor selection (just a number,
+0-3). Both fail at the user's actual job — recognizing what the layout
+looks like at a glance and which physical monitor they're picking.
+
+This module defines visual replacements:
+- ``PatternThumbnail``: a small QFrame rendering each pattern's grid
+  shape via QPainter. Click to select; selected state has an accent
+  border in the user's character accent palette.
+- ``PatternThumbStrip``: a horizontal row of PatternThumbnails. Emits
+  ``pattern_selected(str)`` with the pattern's display name.
+- ``MonitorCard``: a click-target showing monitor index + dimensions
+  + primary marker. Replaces the bare 0-3 spinbox.
+- ``MonitorCardStrip``: a horizontal row of MonitorCards.
+
+PR L1: layout-tab UX pass 1.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QSize, Qt, Signal
+from PySide6.QtGui import QBrush, QColor, QFont, QPainter, QPen
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+# Cell-position layouts for each pattern, normalized to a 4x4 grid so
+# every thumbnail draws into the same canvas. Each entry is a list of
+# (row, col, rowspan, colspan) tuples to stamp into the canvas.
+#
+# Cells are drawn at unit size (100/cols × 100/rows of the canvas) so
+# any pattern fits in the same thumbnail dimensions.
+PATTERN_CELLS: dict[str, list[tuple[int, int, int, int]]] = {
+    "2x2 Grid": [(0, 0, 1, 1), (0, 1, 1, 1), (1, 0, 1, 1), (1, 1, 1, 1)],
+    "3x1 Row": [(0, 0, 1, 1), (0, 1, 1, 1), (0, 2, 1, 1)],
+    "1x3 Column": [(0, 0, 1, 1), (1, 0, 1, 1), (2, 0, 1, 1)],
+    "4x1 Row": [(0, 0, 1, 1), (0, 1, 1, 1), (0, 2, 1, 1), (0, 3, 1, 1)],
+    "2x3 Grid": [
+        (0, 0, 1, 1),
+        (0, 1, 1, 1),
+        (0, 2, 1, 1),
+        (1, 0, 1, 1),
+        (1, 1, 1, 1),
+        (1, 2, 1, 1),
+    ],
+    "3x2 Grid": [
+        (0, 0, 1, 1),
+        (0, 1, 1, 1),
+        (1, 0, 1, 1),
+        (1, 1, 1, 1),
+        (2, 0, 1, 1),
+        (2, 1, 1, 1),
+    ],
+    # "Main + Sides": one big cell on the left (full height, 2/3 width),
+    # 3 stacked cells on the right (1/3 width each).
+    "Main + Sides": [(0, 0, 3, 2), (0, 2, 1, 1), (1, 2, 1, 1), (2, 2, 1, 1)],
+    # Cascade — overlapping diagonal step
+    "Cascade": [(0, 0, 2, 2), (1, 1, 2, 2), (2, 2, 2, 2)],
+    # All overlapping — render as one cell with a small stack indicator
+    "Stacked (All Same Position)": [(1, 1, 2, 2)],
+    # Custom — empty grid outline only, no cells
+    "Custom": [],
+}
+
+
+# Pattern dimensions used to scale unit cells. Format: (rows, cols).
+PATTERN_DIMS: dict[str, tuple[int, int]] = {
+    "2x2 Grid": (2, 2),
+    "3x1 Row": (1, 3),
+    "1x3 Column": (3, 1),
+    "4x1 Row": (1, 4),
+    "2x3 Grid": (2, 3),
+    "3x2 Grid": (3, 2),
+    "Main + Sides": (3, 3),
+    "Cascade": (4, 4),
+    "Stacked (All Same Position)": (4, 4),
+    "Custom": (4, 4),
+}
+
+
+# =============================================================================
+# Pattern thumbnail
+# =============================================================================
+
+
+class PatternThumbnail(QFrame):
+    """
+    Click-to-select thumbnail rendering a single pattern.
+
+    Signals:
+        clicked(str): The pattern's display name when clicked.
+    """
+
+    clicked = Signal(str)
+
+    THUMB_W = 88
+    THUMB_H = 64
+    LABEL_H = 20
+
+    def __init__(self, pattern_name: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.pattern_name = pattern_name
+        self._selected = False
+
+        self.setFixedSize(self.THUMB_W, self.THUMB_H + self.LABEL_H)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+
+        # Spacer for the painted area; the label is drawn underneath.
+        self._canvas_spacer = QWidget()
+        self._canvas_spacer.setFixedHeight(self.THUMB_H)
+        layout.addWidget(self._canvas_spacer)
+
+        self._label = QLabel(pattern_name)
+        self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._label.setStyleSheet("color: #bbb; font-size: 8pt; padding: 0px;")
+        self._label.setWordWrap(True)
+        self._label.setMaximumWidth(self.THUMB_W)
+        layout.addWidget(self._label)
+
+        self._update_style()
+
+    def is_selected(self) -> bool:
+        return self._selected
+
+    def set_selected(self, selected: bool) -> None:
+        if self._selected == selected:
+            return
+        self._selected = selected
+        self._update_style()
+        self.update()
+
+    def _update_style(self) -> None:
+        if self._selected:
+            self.setStyleSheet(
+                """
+                PatternThumbnail {
+                    background-color: #2d3a4a;
+                    border: 2px solid #5a9fff;
+                    border-radius: 4px;
+                }
+                """
+            )
+            self._label.setStyleSheet(
+                "color: #ffffff; font-size: 8pt; font-weight: bold; padding: 0px;"
+            )
+        else:
+            self.setStyleSheet(
+                """
+                PatternThumbnail {
+                    background-color: #2a2a2a;
+                    border: 1px solid #444;
+                    border-radius: 4px;
+                }
+                PatternThumbnail:hover {
+                    background-color: #353535;
+                    border-color: #6a6a6a;
+                }
+                """
+            )
+            self._label.setStyleSheet("color: #bbb; font-size: 8pt; padding: 0px;")
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit(self.pattern_name)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        cells = PATTERN_CELLS.get(self.pattern_name, [])
+        rows, cols = PATTERN_DIMS.get(self.pattern_name, (4, 4))
+
+        # Canvas inset inside the frame border, above the label.
+        pad = 6
+        canvas_x = pad
+        canvas_y = pad
+        canvas_w = self.THUMB_W - pad * 2
+        canvas_h = self.THUMB_H - pad * 2
+
+        painter = QPainter(self)
+        try:
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing, False)
+
+            # Custom: render an empty placeholder
+            if not cells:
+                painter.setPen(QPen(QColor(120, 120, 120), 1, Qt.PenStyle.DashLine))
+                painter.setBrush(QBrush(Qt.BrushStyle.NoBrush))
+                painter.drawRect(canvas_x, canvas_y, canvas_w - 1, canvas_h - 1)
+                # Draw a "?" centered
+                font = QFont(painter.font())
+                font.setPointSize(14)
+                font.setBold(True)
+                painter.setFont(font)
+                painter.setPen(QPen(QColor(150, 150, 150)))
+                painter.drawText(
+                    canvas_x,
+                    canvas_y,
+                    canvas_w,
+                    canvas_h,
+                    Qt.AlignmentFlag.AlignCenter,
+                    "?",
+                )
+                return
+
+            # Stacked is a special case — render overlapping cards
+            if self.pattern_name == "Stacked (All Same Position)":
+                for offset in (0, 4, 8):
+                    rect_x = canvas_x + canvas_w // 4 + offset
+                    rect_y = canvas_y + canvas_h // 4 + offset
+                    rect_w = canvas_w // 2
+                    rect_h = canvas_h // 2
+                    self._draw_cell(painter, rect_x, rect_y, rect_w, rect_h)
+                return
+
+            # Cell-grid render
+            cell_w = canvas_w / cols
+            cell_h = canvas_h / rows
+            for r, c, rspan, cspan in cells:
+                x = canvas_x + int(c * cell_w)
+                y = canvas_y + int(r * cell_h)
+                w = max(1, int(cspan * cell_w) - 2)
+                h = max(1, int(rspan * cell_h) - 2)
+                self._draw_cell(painter, x, y, w, h)
+        finally:
+            painter.end()
+
+    def _draw_cell(self, painter: QPainter, x: int, y: int, w: int, h: int) -> None:
+        """Draw a single cell rect with the selected/unselected fill."""
+        if self._selected:
+            fill = QColor(90, 159, 255, 200)
+            border = QColor(90, 159, 255)
+        else:
+            fill = QColor(110, 110, 110, 180)
+            border = QColor(150, 150, 150)
+        painter.setBrush(QBrush(fill))
+        painter.setPen(QPen(border, 1))
+        painter.drawRect(x, y, w, h)
+
+
+# =============================================================================
+# Pattern thumb strip
+# =============================================================================
+
+
+class PatternThumbStrip(QWidget):
+    """
+    Horizontal row of PatternThumbnails. Single-selection.
+
+    Signals:
+        pattern_selected(str): The pattern display name on selection.
+    """
+
+    pattern_selected = Signal(str)
+
+    def __init__(
+        self,
+        patterns: list[str] | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._thumbnails: dict[str, PatternThumbnail] = {}
+        self._selected: str | None = None
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(2, 2, 2, 2)
+        layout.setSpacing(8)
+
+        names = patterns or list(PATTERN_CELLS.keys())
+        for name in names:
+            thumb = PatternThumbnail(name, parent=self)
+            thumb.clicked.connect(self._on_thumb_clicked)
+            layout.addWidget(thumb)
+            self._thumbnails[name] = thumb
+
+        layout.addStretch()
+
+    def selected_pattern(self) -> str | None:
+        return self._selected
+
+    def set_selected(self, pattern_name: str) -> None:
+        """Highlight the named pattern. Emits pattern_selected if changed."""
+        if pattern_name not in self._thumbnails:
+            return
+        if self._selected == pattern_name:
+            return
+        if self._selected and self._selected in self._thumbnails:
+            self._thumbnails[self._selected].set_selected(False)
+        self._thumbnails[pattern_name].set_selected(True)
+        self._selected = pattern_name
+        self.pattern_selected.emit(pattern_name)
+
+    def _on_thumb_clicked(self, pattern_name: str) -> None:
+        self.set_selected(pattern_name)
+
+
+# =============================================================================
+# Monitor card
+# =============================================================================
+
+
+class MonitorCard(QFrame):
+    """
+    Click-to-select card showing one monitor's index + dimensions.
+
+    Signals:
+        clicked(int): The monitor index when clicked.
+    """
+
+    clicked = Signal(int)
+
+    CARD_W = 140
+    CARD_H = 80
+
+    def __init__(
+        self,
+        index: int,
+        width: int,
+        height: int,
+        is_primary: bool = False,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.index = index
+        self.width_px = width
+        self.height_px = height
+        self.is_primary = is_primary
+        self._selected = False
+
+        self.setFixedSize(self.CARD_W, self.CARD_H)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 6, 8, 6)
+        layout.setSpacing(2)
+
+        index_label = QLabel(f"Monitor {index}")
+        index_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        index_label.setStyleSheet("font-weight: bold; font-size: 10pt;")
+        layout.addWidget(index_label)
+
+        dims_label = QLabel(f"{width} × {height}")
+        dims_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        dims_label.setStyleSheet("color: #aaa; font-size: 9pt;")
+        layout.addWidget(dims_label)
+
+        if is_primary:
+            primary_label = QLabel("Primary")
+            primary_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            primary_label.setStyleSheet("color: #5a9fff; font-size: 8pt; font-style: italic;")
+            layout.addWidget(primary_label)
+        else:
+            layout.addStretch()
+
+        self._update_style()
+
+    def is_selected(self) -> bool:
+        return self._selected
+
+    def set_selected(self, selected: bool) -> None:
+        if self._selected == selected:
+            return
+        self._selected = selected
+        self._update_style()
+
+    def _update_style(self) -> None:
+        if self._selected:
+            self.setStyleSheet(
+                """
+                MonitorCard {
+                    background-color: #2d3a4a;
+                    border: 2px solid #5a9fff;
+                    border-radius: 4px;
+                }
+                """
+            )
+        else:
+            self.setStyleSheet(
+                """
+                MonitorCard {
+                    background-color: #2a2a2a;
+                    border: 1px solid #444;
+                    border-radius: 4px;
+                }
+                MonitorCard:hover {
+                    background-color: #353535;
+                    border-color: #6a6a6a;
+                }
+                """
+            )
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit(self.index)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def sizeHint(self) -> QSize:
+        return QSize(self.CARD_W, self.CARD_H)
+
+
+# =============================================================================
+# Monitor card strip
+# =============================================================================
+
+
+class MonitorCardStrip(QWidget):
+    """
+    Horizontal row of MonitorCards. Single-selection.
+
+    Signals:
+        monitor_selected(int): The monitor index when a card is clicked.
+    """
+
+    monitor_selected = Signal(int)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._cards: dict[int, MonitorCard] = {}
+        self._selected: int | None = None
+
+        self._layout = QHBoxLayout(self)
+        self._layout.setContentsMargins(2, 2, 2, 2)
+        self._layout.setSpacing(8)
+        self._layout.addStretch()
+
+    def card_count(self) -> int:
+        return len(self._cards)
+
+    def selected_index(self) -> int | None:
+        return self._selected
+
+    def set_monitors(self, monitors: list[tuple[int, int, int, bool]]) -> None:
+        """Replace the strip contents.
+
+        Args:
+            monitors: list of (index, width, height, is_primary) tuples.
+        """
+        # Tear down existing cards.
+        for card in list(self._cards.values()):
+            self._layout.removeWidget(card)
+            card.deleteLater()
+        self._cards.clear()
+        self._selected = None
+
+        # Add new cards before the trailing stretch.
+        for index, width, height, is_primary in monitors:
+            card = MonitorCard(index, width, height, is_primary, parent=self)
+            card.clicked.connect(self._on_card_clicked)
+            insert_at = max(0, self._layout.count() - 1)
+            self._layout.insertWidget(insert_at, card)
+            self._cards[index] = card
+
+    def set_selected(self, index: int) -> None:
+        """Highlight the given monitor index. Emits monitor_selected on change."""
+        if index not in self._cards:
+            return
+        if self._selected == index:
+            return
+        if self._selected is not None and self._selected in self._cards:
+            self._cards[self._selected].set_selected(False)
+        self._cards[index].set_selected(True)
+        self._selected = index
+        self.monitor_selected.emit(index)
+
+    def _on_card_clicked(self, index: int) -> None:
+        self.set_selected(index)

--- a/src/argus_overview/ui/layouts_tab.py
+++ b/src/argus_overview/ui/layouts_tab.py
@@ -10,6 +10,7 @@ import subprocess
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
+    QButtonGroup,
     QCheckBox,
     QComboBox,
     QFrame,
@@ -19,6 +20,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QMessageBox,
     QPushButton,
+    QRadioButton,
     QScrollArea,
     QSpinBox,
     QVBoxLayout,
@@ -26,8 +28,9 @@ from PySide6.QtWidgets import (
 )
 
 from argus_overview.core.layout_manager import GridPattern
+from argus_overview.ui.layout_widgets import MonitorCardStrip, PatternThumbStrip
 from argus_overview.ui.main_tab import get_pattern_positions
-from argus_overview.utils.screen import ScreenGeometry, get_screen_geometry
+from argus_overview.utils.screen import ScreenGeometry, get_all_monitors, get_screen_geometry
 
 
 def get_all_patterns():
@@ -412,91 +415,221 @@ class LayoutsTab(QWidget):
         self._on_group_selected()
 
     def _create_top_section(self) -> QWidget:
-        """Create group selector and pattern options"""
-        section = QGroupBox("Layout Configuration")
-        layout = QHBoxLayout()
+        """Create the redesigned top section with thumbnails + monitor cards.
 
-        # Group selector
-        group_layout = QVBoxLayout()
-        group_layout.addWidget(QLabel("Select Group:"))
-
+        Legacy widgets (group_combo, pattern_combo, monitor_spin, etc.) are
+        constructed but NOT added to any visible layout — they continue to
+        hold the canonical state. The new widgets sync into them. This
+        keeps the existing apply path and ~58 test references working
+        without a destabilizing rename.
+        """
+        # ---- Legacy state holders (invisible) -------------------------
+        # The user no longer interacts with these directly, but the apply
+        # path and ~58 existing tests still read .currentText() / .value().
         self.group_combo = QComboBox()
         self._refresh_groups()
         self.group_combo.currentTextChanged.connect(self._on_group_selected)
-        group_layout.addWidget(self.group_combo)
-
-        self.refresh_groups_btn = QPushButton("Refresh Groups")
-        self.refresh_groups_btn.clicked.connect(self._refresh_groups)
-        group_layout.addWidget(self.refresh_groups_btn)
-
-        layout.addLayout(group_layout)
-
-        # Pattern selector
-        pattern_layout = QVBoxLayout()
-        pattern_layout.addWidget(QLabel("Grid Pattern:"))
 
         self.pattern_combo = QComboBox()
         self.pattern_combo.addItems(get_all_patterns())
         self.pattern_combo.currentTextChanged.connect(self._on_pattern_changed)
-        pattern_layout.addWidget(self.pattern_combo)
 
-        self.auto_arrange_btn = QPushButton("Auto-Arrange")
-        self.auto_arrange_btn.clicked.connect(self._auto_arrange)
-        pattern_layout.addWidget(self.auto_arrange_btn)
+        self.monitor_spin = QSpinBox()
+        self.monitor_spin.setRange(0, 3)
+        self.monitor_spin.setValue(0)
 
-        layout.addLayout(pattern_layout)
-
-        # Grid size options
-        size_layout = QVBoxLayout()
-        size_layout.addWidget(QLabel("Grid Size:"))
-
-        size_row = QHBoxLayout()
         self.rows_spin = QSpinBox()
         self.rows_spin.setRange(1, 6)
         self.rows_spin.setValue(3)
         self.rows_spin.setPrefix("Rows: ")
         self.rows_spin.valueChanged.connect(self._update_grid_size)
-        size_row.addWidget(self.rows_spin)
 
         self.cols_spin = QSpinBox()
         self.cols_spin.setRange(1, 6)
         self.cols_spin.setValue(4)
         self.cols_spin.setPrefix("Cols: ")
         self.cols_spin.valueChanged.connect(self._update_grid_size)
-        size_row.addWidget(self.cols_spin)
 
-        size_layout.addLayout(size_row)
-
-        # Spacing
-        spacing_row = QHBoxLayout()
-        spacing_row.addWidget(QLabel("Spacing:"))
         self.spacing_spin = QSpinBox()
         self.spacing_spin.setRange(0, 50)
         self.spacing_spin.setValue(10)
         self.spacing_spin.setSuffix(" px")
-        spacing_row.addWidget(self.spacing_spin)
-        size_layout.addLayout(spacing_row)
 
-        layout.addLayout(size_layout)
-
-        # Monitor selector
-        monitor_layout = QVBoxLayout()
-        monitor_layout.addWidget(QLabel("Monitor:"))
-
-        self.monitor_spin = QSpinBox()
-        self.monitor_spin.setRange(0, 3)
-        self.monitor_spin.setValue(0)
-        monitor_layout.addWidget(self.monitor_spin)
-
-        # Stacking checkbox
         self.stack_checkbox = QCheckBox("Stack Windows")
-        self.stack_checkbox.setToolTip("Place all windows at the same position (overlapping)")
-        monitor_layout.addWidget(self.stack_checkbox)
 
-        layout.addLayout(monitor_layout)
+        self.refresh_groups_btn = QPushButton("Refresh Groups")
+        self.refresh_groups_btn.clicked.connect(self._refresh_groups)
+
+        self.auto_arrange_btn = QPushButton("Auto-Arrange")
+        self.auto_arrange_btn.clicked.connect(self._auto_arrange)
+
+        # ---- Visible top section --------------------------------------
+        container = QWidget()
+        outer = QVBoxLayout(container)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(8)
+
+        # 1. Characters — radio toggle "All / Group: ..."
+        outer.addWidget(self._build_characters_section())
+        # 2. Pattern — thumbnail strip + spacing slider
+        outer.addWidget(self._build_pattern_section())
+        # 3. Monitor — card strip
+        outer.addWidget(self._build_monitor_section())
+        # 4. Grid size — kept compact for Custom pattern users
+        outer.addWidget(self._build_grid_size_section())
+
+        return container
+
+    def _build_characters_section(self) -> QGroupBox:
+        section = QGroupBox("1. Characters")
+        layout = QVBoxLayout()
+
+        radio_row = QHBoxLayout()
+        self._all_radio = QRadioButton("All Active Windows")
+        self._all_radio.setChecked(True)
+        self._group_radio = QRadioButton("Group:")
+        # Parent left as None — Qt re-parents the buttons via addButton anyway,
+        # and bypassed-init test sites can't safely pass `self` as parent.
+        self._group_btn_group = QButtonGroup()
+        self._group_btn_group.addButton(self._all_radio)
+        self._group_btn_group.addButton(self._group_radio)
+
+        # Inline group selector — only enabled when group_radio is on.
+        self._group_inline_combo = QComboBox()
+        self._group_inline_combo.addItem("Default")
+        self._group_inline_combo.setEnabled(False)
+        # Keep the inline combo in sync with the legacy group_combo.
+        self._group_inline_combo.currentTextChanged.connect(self._on_inline_group_changed)
+        self._all_radio.toggled.connect(self._on_chars_radio_toggled)
+        self._group_radio.toggled.connect(self._on_chars_radio_toggled)
+
+        radio_row.addWidget(self._all_radio)
+        radio_row.addWidget(self._group_radio)
+        radio_row.addWidget(self._group_inline_combo, stretch=1)
+        radio_row.addWidget(self.refresh_groups_btn)
+        layout.addLayout(radio_row)
+
+        # Sync inline combo with legacy combo's current items.
+        self._sync_inline_group_combo()
 
         section.setLayout(layout)
         return section
+
+    def _build_pattern_section(self) -> QGroupBox:
+        section = QGroupBox("2. Pattern")
+        layout = QVBoxLayout()
+
+        self._pattern_strip = PatternThumbStrip()
+        self._pattern_strip.pattern_selected.connect(self._on_pattern_strip_selected)
+        # Default selection mirrors the legacy combo
+        initial_pattern = self.pattern_combo.currentText() or "2x2 Grid"
+        self._pattern_strip.set_selected(initial_pattern)
+        layout.addWidget(self._pattern_strip)
+
+        # Spacing belongs with the pattern — it tunes the rendered output,
+        # not a separate concept. Move from the old "Grid Size" cluster.
+        spacing_row = QHBoxLayout()
+        spacing_row.addWidget(QLabel("Spacing:"))
+        spacing_row.addWidget(self.spacing_spin)
+        spacing_row.addStretch()
+        spacing_row.addWidget(self.auto_arrange_btn)
+        layout.addLayout(spacing_row)
+
+        section.setLayout(layout)
+        return section
+
+    def _build_monitor_section(self) -> QGroupBox:
+        section = QGroupBox("3. Monitor")
+        layout = QVBoxLayout()
+
+        self._monitor_strip = MonitorCardStrip()
+        self._monitor_strip.monitor_selected.connect(self._on_monitor_strip_selected)
+        layout.addWidget(self._monitor_strip)
+
+        # Populate from real screen geometry; fall back to a single-card
+        # placeholder when display detection fails (e.g., tests, headless).
+        try:
+            monitors = get_all_monitors() or []
+        except (OSError, RuntimeError, AttributeError):
+            monitors = []
+        cards = [
+            (i, mon.width, mon.height, getattr(mon, "is_primary", i == 0))
+            for i, mon in enumerate(monitors)
+        ]
+        if not cards:
+            cards = [(0, 1920, 1080, True)]
+        self._monitor_strip.set_monitors(cards)
+        self._monitor_strip.set_selected(cards[0][0])
+        # Resize the legacy spin range to match real monitor count.
+        self.monitor_spin.setRange(0, max(0, len(cards) - 1))
+
+        section.setLayout(layout)
+        return section
+
+    def _build_grid_size_section(self) -> QGroupBox:
+        section = QGroupBox("4. Grid Size")
+        layout = QHBoxLayout()
+        layout.addWidget(self.rows_spin)
+        layout.addWidget(self.cols_spin)
+        layout.addStretch()
+        self.stack_checkbox.setToolTip("Place all windows at the same position (overlapping).")
+        layout.addWidget(self.stack_checkbox)
+        section.setLayout(layout)
+        return section
+
+    # ---- New-widget → legacy-state sync -----------------------------------
+    def _on_chars_radio_toggled(self) -> None:
+        """Mirror the radio choice into the legacy group_combo."""
+        if self._all_radio.isChecked():
+            self._group_inline_combo.setEnabled(False)
+            # Trigger the legacy "All Active Windows" code path.
+            idx = self.group_combo.findText("All Active Windows")
+            if idx >= 0:
+                self.group_combo.setCurrentIndex(idx)
+        else:
+            self._group_inline_combo.setEnabled(True)
+            # Switch to the currently-selected inline group.
+            self._on_inline_group_changed(self._group_inline_combo.currentText())
+
+    def _on_inline_group_changed(self, group_name: str) -> None:
+        """Mirror the inline group combo into the legacy combo."""
+        if not group_name:
+            return
+        idx = self.group_combo.findText(group_name)
+        if idx >= 0:
+            self.group_combo.setCurrentIndex(idx)
+
+    def _on_pattern_strip_selected(self, pattern_name: str) -> None:
+        """Mirror the thumbnail strip choice into the legacy pattern combo."""
+        idx = self.pattern_combo.findText(pattern_name)
+        if idx >= 0:
+            self.pattern_combo.setCurrentIndex(idx)
+
+    def _on_monitor_strip_selected(self, index: int) -> None:
+        """Mirror the monitor card choice into the legacy spinbox."""
+        self.monitor_spin.setValue(index)
+
+    def _sync_inline_group_combo(self) -> None:
+        """Refresh the inline group combo from cycling_groups.
+
+        No-op on bypassed-init test sites that don't have the inline combo
+        or cycling_groups dict.
+        """
+        if not hasattr(self, "_group_inline_combo"):
+            return
+        groups = getattr(self, "cycling_groups", None)
+        if groups is None:
+            return
+        current = self._group_inline_combo.currentText()
+        self._group_inline_combo.blockSignals(True)
+        self._group_inline_combo.clear()
+        for name in sorted(groups.keys()):
+            self._group_inline_combo.addItem(name)
+        if current:
+            i = self._group_inline_combo.findText(current)
+            if i >= 0:
+                self._group_inline_combo.setCurrentIndex(i)
+        self._group_inline_combo.blockSignals(False)
 
     def _create_grid_section(self) -> QWidget:
         """Create arrangement grid"""
@@ -581,6 +714,9 @@ class LayoutsTab(QWidget):
                 self.group_combo.setCurrentIndex(idx)
 
         self.group_combo.blockSignals(False)
+
+        # Keep the new inline group combo in sync.
+        self._sync_inline_group_combo()
 
         self.logger.info(f"Loaded {len(self.cycling_groups)} groups")
 

--- a/tests/test_layout_widgets.py
+++ b/tests/test_layout_widgets.py
@@ -1,0 +1,282 @@
+"""Tests for the Layouts-tab visual widgets (PR L1)."""
+
+from PySide6.QtCore import QPointF, Qt
+from PySide6.QtGui import QMouseEvent
+
+from argus_overview.ui.layout_widgets import (
+    PATTERN_CELLS,
+    MonitorCard,
+    MonitorCardStrip,
+    PatternThumbnail,
+    PatternThumbStrip,
+)
+
+
+def _click(widget, x: int = 5, y: int = 5):
+    event = QMouseEvent(
+        QMouseEvent.Type.MouseButtonPress,
+        QPointF(float(x), float(y)),
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    widget.mousePressEvent(event)
+
+
+# =============================================================================
+# PatternThumbnail
+# =============================================================================
+
+
+class TestPatternThumbnail:
+    def test_default_state(self, qapp):
+        thumb = PatternThumbnail("2x2 Grid")
+        try:
+            assert thumb.pattern_name == "2x2 Grid"
+            assert thumb.is_selected() is False
+        finally:
+            thumb.deleteLater()
+
+    def test_set_selected(self, qapp):
+        thumb = PatternThumbnail("Cascade")
+        try:
+            thumb.set_selected(True)
+            assert thumb.is_selected() is True
+            thumb.set_selected(False)
+            assert thumb.is_selected() is False
+        finally:
+            thumb.deleteLater()
+
+    def test_set_selected_idempotent(self, qapp):
+        thumb = PatternThumbnail("2x2 Grid")
+        try:
+            thumb.set_selected(True)
+            thumb.set_selected(True)  # no-op
+            assert thumb.is_selected() is True
+        finally:
+            thumb.deleteLater()
+
+    def test_click_emits_pattern_name(self, qapp):
+        thumb = PatternThumbnail("3x1 Row")
+        try:
+            received: list[str] = []
+            thumb.clicked.connect(received.append)
+            _click(thumb)
+            assert received == ["3x1 Row"]
+        finally:
+            thumb.deleteLater()
+
+    def test_paint_with_cells_does_not_crash(self, qapp):
+        thumb = PatternThumbnail("Main + Sides")
+        try:
+            thumb.resize(thumb.THUMB_W, thumb.THUMB_H + thumb.LABEL_H)
+            thumb.repaint()
+        finally:
+            thumb.deleteLater()
+
+    def test_paint_custom_pattern_does_not_crash(self, qapp):
+        thumb = PatternThumbnail("Custom")
+        try:
+            thumb.resize(thumb.THUMB_W, thumb.THUMB_H + thumb.LABEL_H)
+            thumb.repaint()
+        finally:
+            thumb.deleteLater()
+
+    def test_paint_stacked_pattern_does_not_crash(self, qapp):
+        thumb = PatternThumbnail("Stacked (All Same Position)")
+        try:
+            thumb.resize(thumb.THUMB_W, thumb.THUMB_H + thumb.LABEL_H)
+            thumb.repaint()
+        finally:
+            thumb.deleteLater()
+
+    def test_every_documented_pattern_renders(self, qapp):
+        # Sanity: each pattern in PATTERN_CELLS can construct + paint.
+        for name in PATTERN_CELLS:
+            thumb = PatternThumbnail(name)
+            try:
+                thumb.resize(thumb.THUMB_W, thumb.THUMB_H + thumb.LABEL_H)
+                thumb.repaint()
+            finally:
+                thumb.deleteLater()
+
+
+# =============================================================================
+# PatternThumbStrip
+# =============================================================================
+
+
+class TestPatternThumbStrip:
+    def test_default_no_selection(self, qapp):
+        strip = PatternThumbStrip(["2x2 Grid", "3x1 Row"])
+        try:
+            assert strip.selected_pattern() is None
+        finally:
+            strip.deleteLater()
+
+    def test_set_selected_changes_pattern(self, qapp):
+        strip = PatternThumbStrip(["2x2 Grid", "3x1 Row"])
+        try:
+            received: list[str] = []
+            strip.pattern_selected.connect(received.append)
+            strip.set_selected("3x1 Row")
+            assert strip.selected_pattern() == "3x1 Row"
+            assert received == ["3x1 Row"]
+        finally:
+            strip.deleteLater()
+
+    def test_set_selected_unknown_pattern_noop(self, qapp):
+        strip = PatternThumbStrip(["2x2 Grid"])
+        try:
+            received: list[str] = []
+            strip.pattern_selected.connect(received.append)
+            strip.set_selected("DoesNotExist")
+            assert strip.selected_pattern() is None
+            assert received == []
+        finally:
+            strip.deleteLater()
+
+    def test_set_selected_dedupes(self, qapp):
+        strip = PatternThumbStrip(["2x2 Grid", "3x1 Row"])
+        try:
+            received: list[str] = []
+            strip.pattern_selected.connect(received.append)
+            strip.set_selected("2x2 Grid")
+            strip.set_selected("2x2 Grid")  # no-op
+            assert received == ["2x2 Grid"]
+        finally:
+            strip.deleteLater()
+
+    def test_clicking_thumb_selects_strip_pattern(self, qapp):
+        strip = PatternThumbStrip(["2x2 Grid", "3x1 Row", "Cascade"])
+        try:
+            received: list[str] = []
+            strip.pattern_selected.connect(received.append)
+            # Find the Cascade thumbnail and click it
+            thumb = strip._thumbnails["Cascade"]
+            _click(thumb)
+            assert strip.selected_pattern() == "Cascade"
+            assert received == ["Cascade"]
+        finally:
+            strip.deleteLater()
+
+    def test_changing_selection_clears_previous(self, qapp):
+        strip = PatternThumbStrip(["2x2 Grid", "3x1 Row"])
+        try:
+            strip.set_selected("2x2 Grid")
+            strip.set_selected("3x1 Row")
+            assert strip._thumbnails["2x2 Grid"].is_selected() is False
+            assert strip._thumbnails["3x1 Row"].is_selected() is True
+        finally:
+            strip.deleteLater()
+
+
+# =============================================================================
+# MonitorCard
+# =============================================================================
+
+
+class TestMonitorCard:
+    def test_default_state(self, qapp):
+        card = MonitorCard(0, 1920, 1080, is_primary=True)
+        try:
+            assert card.index == 0
+            assert card.width_px == 1920
+            assert card.height_px == 1080
+            assert card.is_primary is True
+            assert card.is_selected() is False
+        finally:
+            card.deleteLater()
+
+    def test_set_selected(self, qapp):
+        card = MonitorCard(1, 2560, 1440)
+        try:
+            card.set_selected(True)
+            assert card.is_selected() is True
+            card.set_selected(False)
+            assert card.is_selected() is False
+        finally:
+            card.deleteLater()
+
+    def test_click_emits_index(self, qapp):
+        card = MonitorCard(2, 3840, 2160, is_primary=False)
+        try:
+            received: list[int] = []
+            card.clicked.connect(received.append)
+            _click(card)
+            assert received == [2]
+        finally:
+            card.deleteLater()
+
+
+# =============================================================================
+# MonitorCardStrip
+# =============================================================================
+
+
+class TestMonitorCardStrip:
+    def test_default_empty(self, qapp):
+        strip = MonitorCardStrip()
+        try:
+            assert strip.card_count() == 0
+            assert strip.selected_index() is None
+        finally:
+            strip.deleteLater()
+
+    def test_set_monitors_creates_cards(self, qapp):
+        strip = MonitorCardStrip()
+        try:
+            strip.set_monitors(
+                [
+                    (0, 1920, 1080, True),
+                    (1, 2560, 1440, False),
+                ]
+            )
+            assert strip.card_count() == 2
+        finally:
+            strip.deleteLater()
+
+    def test_set_monitors_replaces_previous(self, qapp):
+        strip = MonitorCardStrip()
+        try:
+            strip.set_monitors([(0, 1920, 1080, True)])
+            strip.set_monitors([(0, 2560, 1440, False), (1, 1920, 1080, True)])
+            assert strip.card_count() == 2
+            assert strip.selected_index() is None  # prior selection cleared
+        finally:
+            strip.deleteLater()
+
+    def test_set_selected_emits(self, qapp):
+        strip = MonitorCardStrip()
+        try:
+            strip.set_monitors([(0, 1920, 1080, True), (1, 2560, 1440, False)])
+            received: list[int] = []
+            strip.monitor_selected.connect(received.append)
+            strip.set_selected(1)
+            assert strip.selected_index() == 1
+            assert received == [1]
+        finally:
+            strip.deleteLater()
+
+    def test_set_selected_unknown_index_noop(self, qapp):
+        strip = MonitorCardStrip()
+        try:
+            strip.set_monitors([(0, 1920, 1080, True)])
+            received: list[int] = []
+            strip.monitor_selected.connect(received.append)
+            strip.set_selected(99)
+            assert received == []
+        finally:
+            strip.deleteLater()
+
+    def test_clicking_card_selects_strip(self, qapp):
+        strip = MonitorCardStrip()
+        try:
+            strip.set_monitors([(0, 1920, 1080, True), (1, 2560, 1440, False)])
+            received: list[int] = []
+            strip.monitor_selected.connect(received.append)
+            _click(strip._cards[1])
+            assert strip.selected_index() == 1
+            assert received == [1]
+        finally:
+            strip.deleteLater()

--- a/tests/test_layouts_tab.py
+++ b/tests/test_layouts_tab.py
@@ -1702,11 +1702,17 @@ class TestLayoutsTabCreateTopSection:
 
                 result = tab._create_top_section()
 
-                # Verify section created
-                mock_groupbox_cls.assert_called_with("Layout Configuration")
-                assert result == mock_section
+                # Verify section created — top section now has 4 group boxes
+                # (Characters, Pattern, Monitor, Grid Size) instead of one.
+                assert mock_groupbox_cls.call_count >= 4
+                titles = [c.args[0] for c in mock_groupbox_cls.call_args_list]
+                assert any("Characters" in t for t in titles)
+                assert any("Pattern" in t for t in titles)
+                assert any("Monitor" in t for t in titles)
+                assert result is not None
 
-                # Verify combos created for group and pattern
+                # Verify combos created for group and pattern (3 now: legacy
+                # group, legacy pattern, inline group selector).
                 assert mock_combo_cls.call_count >= 2
                 tab._refresh_groups.assert_called_once()
 


### PR DESCRIPTION
## Why
Direct user feedback that the Layouts tab top section was structurally confusing:
- Pattern names without thumbnails — \"Main + Sides\", \"Cascade\" mean nothing until applied
- Monitor as a 0-3 spinbox with no names or dimensions
- Pattern / Grid Size / Stack Windows checkbox / \"Stacked\" pattern — four overlapping controls fighting each other
- \"All Active Windows\" hidden as a magic dropdown item
- Spacing buried in the Grid Size cluster (it actually tunes pattern output)

## What changes
**New widgets** (\`ui/layout_widgets.py\`):
- \`PatternThumbnail\` — renders a mini-grid preview of each pattern in QPainter. Cascade shows overlapping diagonal cards, Stacked shows layered offset cards, Custom shows a dashed \"?\" placeholder. Selected state has accent border.
- \`PatternThumbStrip\` — horizontal row of thumbnails with click-to-select, single-selection mutex
- \`MonitorCard\` — index + dimensions (\"Monitor 1 — 2560 × 1440 — Primary\")
- \`MonitorCardStrip\` — populated from \`get_all_monitors()\` at build time

**Tab restructure** (\`ui/layouts_tab.py\`):
| Old | New |
|---|---|
| 1 GroupBox \"Layout Configuration\" with 4 packed columns | 4 numbered sections: \`1. Characters\` (radio: All / Group), \`2. Pattern\` (thumb strip + Spacing), \`3. Monitor\` (card strip), \`4. Grid Size\` (rows/cols + Stack) |
| Spacing in Grid Size cluster | Spacing under Pattern (where it belongs) |
| Group combo with magic \"All Active Windows\" item | Radio buttons + inline group selector |

## Behavior unchanged
The apply path is **identical**. Legacy widgets (\`group_combo\`, \`pattern_combo\`, \`monitor_spin\`, \`rows_spin\`, \`cols_spin\`, \`spacing_spin\`, \`stack_checkbox\`) are kept as invisible state holders driven by the new pickers via mirror slots. \`_apply_to_active_windows\` still reads \`.currentText()\` / \`.value()\` exactly as before, and ~58 existing test references work without rewrites.

## Out of scope (saved for pass 2)
- **Live preview** of resulting layout on the chosen monitor — significant lift, separate PR
- **Hide rows/cols** when non-Custom pattern is selected — behavior change, want UI feedback first
- **Drag-loss confirm dialog** — drag wiring may not even work currently; verify via smoke test before adding

## Test plan
- [x] 23 new tests in \`tests/test_layout_widgets.py\` (state, paint smoke for all 10 patterns, click → emit, selection mutex, unknown-input no-op)
- [x] 1 existing test updated for new section structure (asserts 4 group boxes + section titles instead of single \"Layout Configuration\")
- [x] Full suite: **2434 passed, 5 skipped, 0 failures**
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Manual smoke test against EVE clients per \`docs/SMOKE_TEST_v3.2.0.md\` — find what still feels broken before pass 2

## Visual layout (mental model)
\`\`\`
┌─ 1. Characters ──────────────────────────────────────────┐
│  ◉ All Active Windows   ○ Group: [Default ▼]  [Refresh] │
├─ 2. Pattern ─────────────────────────────────────────────┤
│  ┌──┬──┐  ┌──┬──┬──┐  ┌──────┬──┐  ┌────┐                │
│  │  │  │  │  │  │  │  │      │  │  │ ╲╲ │  ...           │
│  ├──┼──┤  └──┴──┴──┘  │ Main ├──┤  │ ╲╲ │                │
│  │ ●│  │   3x1 Row    │      │  │  │ ╲╲ │                │
│  └──┴──┘              └──────┴──┘  └────┘                │
│   2x2                                                    │
│  Spacing: [─●──────] 10 px         [Auto-Arrange]        │
├─ 3. Monitor ─────────────────────────────────────────────┤
│  ┌────────────┐  ┌────────────┐                          │
│  │ Monitor 0  │  │ Monitor 1●│   (click to select)       │
│  │ 1920×1080  │  │ 2560×1440  │                          │
│  │ Primary    │  │            │                          │
│  └────────────┘  └────────────┘                          │
├─ 4. Grid Size ───────────────────────────────────────────┤
│  [Rows: 3] [Cols: 4]              [☐ Stack Windows]      │
└──────────────────────────────────────────────────────────┘
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)